### PR TITLE
feat(contract): per-node compose/volumes override (app-level default) — #535

### DIFF
--- a/contract/CONTRACTS.md
+++ b/contract/CONTRACTS.md
@@ -45,7 +45,8 @@ TAPP_REGISTRY_CONTRACT=0x95a0BF4148b30F6F8D86870534c51df46Da5511c
 
 | Contract | Address |
 |----------|---------|
-| TappRegistry Implementation | `0xaeddc6b6A6b9d4a9513Cc2322bbb78DFF97DA459` |
+| TappRegistry Implementation (initial) | `0xaeddc6b6A6b9d4a9513Cc2322bbb78DFF97DA459` |
+| **TappRegistry Implementation (current, getNode resolves inherit)** | `0x6987fD9afe6e2430bF5AD85cfBC8c63487d4e4BD` |
 | UpgradeableBeacon | `0x1Cd7544068AdC525b9Cb21cC13aF25D95a53645E` |
 | **BeaconProxy (stable)** | `0x2Ce80374318B1d7Fb3345724457a182E0ad165c9` |
 
@@ -211,8 +212,9 @@ docker run --rm --entrypoint cast ghcr.io/foundry-rs/foundry:latest \
 docker run --rm --entrypoint cast ghcr.io/foundry-rs/foundry:latest \
   call <PROXY> "getAppInfo(string)((bytes,bytes,bytes[],address,uint256))" "<APP_ID>" --rpc-url <RPC_URL>
 
-# Node info — teeUrl, addedAt, stakeAmount, composeHash, volumesHash. The compose/volumes
-# here are this node's OVERRIDE; empty means it inherits the app-level default above.
+# Node info — teeUrl, addedAt, stakeAmount, composeHash, volumesHash. getNode returns the
+# node's EFFECTIVE compose/volumes: its own override if set, else the app-level default
+# resolved in. (Storage holds empty = inherit; the raw override is in the NodeCode event.)
 docker run --rm --entrypoint cast ghcr.io/foundry-rs/foundry:latest \
   call <PROXY> "getNode(string,address)((string,uint256,uint256,bytes,bytes))" "<APP_ID>" "<SIGNER>" --rpc-url <RPC_URL>
 ```

--- a/contract/CONTRACTS.md
+++ b/contract/CONTRACTS.md
@@ -34,6 +34,25 @@ RPC: https://evmrpc-testnet.0g.ai
 TAPP_REGISTRY_CONTRACT=0x95a0BF4148b30F6F8D86870534c51df46Da5511c
 ```
 
+#### Per-node-compose e2e test instance (branch `fix/tappregistry-per-node-compose-hash`)
+
+> Standalone throwaway instance deployed to e2e-test the per-node compose/volumes
+> change (issue #535). NOT the canonical Dev registry above — the live beacon was
+> not touched. Safe to discard. All three contracts source-verified on the explorer.
+
+**Deployed:** 2026-06-23  **Deployer:** `0xea695C312CE119dE347425B29AFf85371c9d1837`
+**Min stake:** 1 0G  **Lock:** 86400 s
+
+| Contract | Address |
+|----------|---------|
+| TappRegistry Implementation | `0xaeddc6b6A6b9d4a9513Cc2322bbb78DFF97DA459` |
+| UpgradeableBeacon | `0x1Cd7544068AdC525b9Cb21cC13aF25D95a53645E` |
+| **BeaconProxy (stable)** | `0x2Ce80374318B1d7Fb3345724457a182E0ad165c9` |
+
+e2e exercised on app `0g-kms`: register-onchain (app-level default + first node
+inherit), add-node-onchain (per-node override), update-node-onchain — all verified
+on-chain via getNode/getAppInfo.
+
 ### Testnet
 
 > To be deployed.
@@ -59,6 +78,13 @@ tapp-cli / user  ──►  BeaconProxy  (stable address, all state lives here)
 ```
 
 **The proxy address never changes.** Upgrades only replace the implementation.
+
+**App model:** `composeHash`/`volumesHash`/`imageHashes` at the app level are the
+**shared defaults** for all nodes. A node MAY override `composeHash`/`volumesHash` in
+its `NodeInfo` (for node-specific config); the effective value for a node is its own
+override if non-empty, else the app-level default. `imageHashes` are always shared.
+`registerApp`/`updateApp` set the app-level defaults; `addNode`/`updateNode` take an
+optional per-node override (empty = inherit).
 
 ---
 
@@ -152,6 +178,11 @@ tapp-cli \
 
 ### Update app hashes (after redeployment)
 
+`update-onchain` updates the app-level shared defaults (compose/volumes/images). If a
+specific node diverges from the defaults, set its per-node override with
+`update-node-onchain` (same old/new signer to keep the node; it fetches that node's
+current compose/volumes from `--server`).
+
 ```bash
 tapp-cli \
   --server http://<TAPP_SERVER>:50051 \
@@ -175,7 +206,13 @@ docker run --rm --entrypoint cast ghcr.io/foundry-rs/foundry:latest \
 docker run --rm --entrypoint cast ghcr.io/foundry-rs/foundry:latest \
   call <PROXY> "minStakeAmount()(uint256)" --rpc-url <RPC_URL>
 
-# App info
+# App info — composeHash/volumesHash here are the app-level SHARED DEFAULTS; imageHashes
+# is always shared. A node may override compose/volumes (see getNode below).
 docker run --rm --entrypoint cast ghcr.io/foundry-rs/foundry:latest \
   call <PROXY> "getAppInfo(string)((bytes,bytes,bytes[],address,uint256))" "<APP_ID>" --rpc-url <RPC_URL>
+
+# Node info — teeUrl, addedAt, stakeAmount, composeHash, volumesHash. The compose/volumes
+# here are this node's OVERRIDE; empty means it inherits the app-level default above.
+docker run --rm --entrypoint cast ghcr.io/foundry-rs/foundry:latest \
+  call <PROXY> "getNode(string,address)((string,uint256,uint256,bytes,bytes))" "<APP_ID>" "<SIGNER>" --rpc-url <RPC_URL>
 ```

--- a/contract/src/TappRegistry.sol
+++ b/contract/src/TappRegistry.sol
@@ -57,9 +57,10 @@ contract TappRegistry {
         string  teeUrl;
         uint256 addedAt;
         uint256 stakeAmount;
-        /// @dev OPTIONAL per-node override of the app-level composeHash. Empty means
-        ///      "inherit the app-level default". Appended after stakeAmount to keep the
-        ///      storage layout upgrade-compatible (existing nodes read empty = inherit).
+        /// @dev OPTIONAL per-node override of the app-level composeHash. Empty in storage
+        ///      means "inherit the app-level default"; getNode() resolves it to the
+        ///      default on read (raw override is still observable via the NodeCode event).
+        ///      Appended after stakeAmount to keep the storage layout upgrade-compatible.
         bytes   composeHash;
         /// @dev OPTIONAL per-node override of the app-level volumesHash (see composeHash).
         bytes   volumesHash;
@@ -495,11 +496,22 @@ contract TappRegistry {
         return _appAckVersions[appId];
     }
 
+    /// @notice Returns a node's info with its EFFECTIVE compose/volumes resolved: if the
+    ///         node's per-node override is empty (inherit), the app-level default is
+    ///         substituted in the returned struct. (Storage still holds empty = inherit;
+    ///         the raw override is observable via the NodeCode event.) A non-existent
+    ///         node (addedAt == 0) is returned as-is without substitution.
     function getNode(
         string  calldata appId,
         address          signerAddress
     ) external view returns (NodeInfo memory) {
-        return _nodes[appId][signerAddress];
+        NodeInfo memory node = _nodes[appId][signerAddress];
+        if (node.addedAt != 0) {
+            AppInfo storage app = _apps[appId];
+            if (node.composeHash.length == 0) node.composeHash = app.composeHash;
+            if (node.volumesHash.length == 0) node.volumesHash = app.volumesHash;
+        }
+        return node;
     }
 
     /// @notice Active node list. Entries are removed immediately when a node is removed.

--- a/contract/test/TappRegistry.t.sol
+++ b/contract/test/TappRegistry.t.sol
@@ -270,20 +270,20 @@ contract TappRegistryTest is Test {
         vm.prank(owner);
         registry.addNode{value: MIN_STAKE}(APP_ID, node2, TEE_URL_2, hex"", hex"");
 
-        // Empty per-node override means "inherit the app-level default":
-        // the node carries no own code; the app-level COMPOSE_HASH/VOLUMES_HASH
-        // (in getAppInfo) remains authoritative.
+        // Empty per-node override means "inherit the app-level default": getNode
+        // resolves the empty override to the app-level COMPOSE_HASH/VOLUMES_HASH.
         TappRegistry.NodeInfo memory n = registry.getNode(APP_ID, node2);
-        assertEq(n.composeHash, hex"");
-        assertEq(n.volumesHash, hex"");
+        assertEq(n.composeHash, COMPOSE_HASH);
+        assertEq(n.volumesHash, VOLUMES_HASH);
     }
 
-    function test_RegisterApp_FirstNode_HasEmptyOverride() public {
+    function test_RegisterApp_FirstNode_InheritsAppDefault() public {
         _register();
-        // registerApp's first node inherits the app-level default => empty override.
+        // registerApp's first node has an empty override (inherit); getNode resolves it
+        // to the app-level default. (Raw-empty is covered by the NodeCode event test.)
         TappRegistry.NodeInfo memory n = registry.getNode(APP_ID, node1);
-        assertEq(n.composeHash, hex"");
-        assertEq(n.volumesHash, hex"");
+        assertEq(n.composeHash, COMPOSE_HASH);
+        assertEq(n.volumesHash, VOLUMES_HASH);
     }
 
     function test_UpdateNode_SetsPerNodeOverride() public {
@@ -307,12 +307,12 @@ contract TappRegistryTest is Test {
         );
         assertEq(registry.getNode(APP_ID, node1).composeHash, NODE_COMPOSE_OVERRIDE);
 
-        // ...then clear it back to inherit (empty bytes).
+        // ...then clear it back to inherit (empty bytes): getNode resolves to app default.
         vm.prank(owner);
         registry.updateNode(APP_ID, node1, node1, TEE_URL_1, hex"", hex"");
         TappRegistry.NodeInfo memory n = registry.getNode(APP_ID, node1);
-        assertEq(n.composeHash, hex"");
-        assertEq(n.volumesHash, hex"");
+        assertEq(n.composeHash, COMPOSE_HASH);
+        assertEq(n.volumesHash, VOLUMES_HASH);
     }
 
     // ─── NodeCode event coverage ──────────────────────────────────────────────
@@ -714,17 +714,18 @@ contract TappRegistryTest is Test {
         address[] memory nodes = reg.getNodeList(APP_ID);
         assertEq(nodes.length, 2);
 
-        // 4c. Old node fields preserved; appended override fields default to empty (= inherit).
+        // 4c. Old node fields preserved; appended override is empty in storage (= inherit),
+        //     so getNode resolves it to the app-level default.
         TappRegistry.NodeInfo memory n1 = reg.getNode(APP_ID, node1);
         assertEq(n1.teeUrl,      TEE_URL_1);
         assertEq(n1.stakeAmount, MIN_STAKE);
         assertEq(n1.addedAt,     node1AddedAt);
-        assertEq(n1.composeHash, hex"");
-        assertEq(n1.volumesHash, hex"");
+        assertEq(n1.composeHash, COMPOSE_HASH);   // inherited (resolved by getNode)
+        assertEq(n1.volumesHash, VOLUMES_HASH);
         TappRegistry.NodeInfo memory n2 = reg.getNode(APP_ID, node2);
         assertEq(n2.teeUrl,      TEE_URL_2);
-        assertEq(n2.composeHash, hex"");
-        assertEq(n2.volumesHash, hex"");
+        assertEq(n2.composeHash, COMPOSE_HASH);
+        assertEq(n2.volumesHash, VOLUMES_HASH);
 
         // 5. New per-node override paths work on the upgraded proxy.
         vm.prank(owner);

--- a/contract/test/TappRegistry.t.sol
+++ b/contract/test/TappRegistry.t.sol
@@ -6,6 +6,7 @@ import {Vm} from "forge-std/Vm.sol";
 import {TappRegistry} from "../src/TappRegistry.sol";
 import {UpgradeableBeacon} from "../src/proxy/UpgradeableBeacon.sol";
 import {BeaconProxy} from "../src/proxy/BeaconProxy.sol";
+import {TappRegistryV1} from "./fixtures/TappRegistryV1.sol";
 
 contract TappRegistryTest is Test {
     TappRegistry public registry;
@@ -24,6 +25,10 @@ contract TappRegistryTest is Test {
     bytes   constant VOLUMES_HASH = hex"ccdd";
     string  constant TEE_URL_1    = "https://node1.example.com";
     string  constant TEE_URL_2    = "https://node2.example.com";
+
+    // Per-node code overrides (distinct from the app-level defaults above).
+    bytes   constant NODE_COMPOSE_OVERRIDE = hex"aa";
+    bytes   constant NODE_VOLUMES_OVERRIDE = hex"bb";
 
     bytes[] imageHashes;
 
@@ -54,7 +59,7 @@ contract TappRegistryTest is Test {
     function _registerTwo() internal {
         _register();
         vm.prank(owner);
-        registry.addNode{value: MIN_STAKE}(APP_ID, node2, TEE_URL_2);
+        registry.addNode{value: MIN_STAKE}(APP_ID, node2, TEE_URL_2, hex"", hex"");
     }
 
     // ─── registerApp ──────────────────────────────────────────────────────────
@@ -138,7 +143,7 @@ contract TappRegistryTest is Test {
     function test_AddNode() public {
         _register();
         vm.prank(owner);
-        registry.addNode{value: MIN_STAKE}(APP_ID, node2, TEE_URL_2);
+        registry.addNode{value: MIN_STAKE}(APP_ID, node2, TEE_URL_2, hex"", hex"");
 
         TappRegistry.NodeInfo memory node = registry.getNode(APP_ID, node2);
         assertEq(node.stakeAmount, MIN_STAKE);
@@ -152,7 +157,7 @@ contract TappRegistryTest is Test {
         _register();
         assertEq(registry.getAckVersion(APP_ID), 1);
         vm.prank(owner);
-        registry.addNode{value: MIN_STAKE}(APP_ID, node2, TEE_URL_2);
+        registry.addNode{value: MIN_STAKE}(APP_ID, node2, TEE_URL_2, hex"", hex"");
         assertEq(registry.getAckVersion(APP_ID), 2);
     }
 
@@ -163,7 +168,7 @@ contract TappRegistryTest is Test {
         assertTrue(registry.isAcknowledged(user, APP_ID));
 
         vm.prank(owner);
-        registry.addNode{value: MIN_STAKE}(APP_ID, node2, TEE_URL_2);
+        registry.addNode{value: MIN_STAKE}(APP_ID, node2, TEE_URL_2, hex"", hex"");
         assertFalse(registry.isAcknowledged(user, APP_ID));
     }
 
@@ -171,21 +176,21 @@ contract TappRegistryTest is Test {
         _register();
         vm.expectRevert("not app owner");
         vm.prank(hacker);
-        registry.addNode{value: MIN_STAKE}(APP_ID, node2, TEE_URL_2);
+        registry.addNode{value: MIN_STAKE}(APP_ID, node2, TEE_URL_2, hex"", hex"");
     }
 
     function test_AddNode_Revert_NodeAlreadyExists() public {
         _register();
         vm.expectRevert("node already exists");
         vm.prank(owner);
-        registry.addNode{value: MIN_STAKE}(APP_ID, node1, TEE_URL_1);
+        registry.addNode{value: MIN_STAKE}(APP_ID, node1, TEE_URL_1, hex"", hex"");
     }
 
     function test_AddNode_Revert_InsufficientStake() public {
         _register();
         vm.expectRevert("insufficient stake");
         vm.prank(owner);
-        registry.addNode{value: 0.1 ether}(APP_ID, node2, TEE_URL_2);
+        registry.addNode{value: 0.1 ether}(APP_ID, node2, TEE_URL_2, hex"", hex"");
     }
 
     // ─── updateNode ───────────────────────────────────────────────────────────
@@ -193,7 +198,7 @@ contract TappRegistryTest is Test {
     function test_UpdateNode_ReplacesSignerAndTeeUrl() public {
         _register();
         vm.prank(owner);
-        registry.updateNode(APP_ID, node1, node2, TEE_URL_2);
+        registry.updateNode(APP_ID, node1, node2, TEE_URL_2, hex"", hex"");
 
         // old node gone
         assertEq(registry.getNode(APP_ID, node1).addedAt, 0);
@@ -210,7 +215,7 @@ contract TappRegistryTest is Test {
     function test_UpdateNode_IncrementsAckVersion() public {
         _register();
         vm.prank(owner);
-        registry.updateNode(APP_ID, node1, node2, TEE_URL_2);
+        registry.updateNode(APP_ID, node1, node2, TEE_URL_2, hex"", hex"");
         assertEq(registry.getAckVersion(APP_ID), 2);
     }
 
@@ -221,7 +226,7 @@ contract TappRegistryTest is Test {
         assertTrue(registry.isAcknowledged(user, APP_ID));
 
         vm.prank(owner);
-        registry.updateNode(APP_ID, node1, node2, TEE_URL_2);
+        registry.updateNode(APP_ID, node1, node2, TEE_URL_2, hex"", hex"");
         assertFalse(registry.isAcknowledged(user, APP_ID));
     }
 
@@ -229,21 +234,146 @@ contract TappRegistryTest is Test {
         _register();
         vm.expectRevert("old node not found");
         vm.prank(owner);
-        registry.updateNode(APP_ID, node2, makeAddr("node3"), TEE_URL_2);
+        registry.updateNode(APP_ID, node2, makeAddr("node3"), TEE_URL_2, hex"", hex"");
     }
 
     function test_UpdateNode_Revert_NewSignerAlreadyExists() public {
         _registerTwo();
         vm.expectRevert("new signer already exists");
         vm.prank(owner);
-        registry.updateNode(APP_ID, node1, node2, TEE_URL_2);
+        registry.updateNode(APP_ID, node1, node2, TEE_URL_2, hex"", hex"");
     }
 
     function test_UpdateNode_Revert_NotOwner() public {
         _register();
         vm.expectRevert("not app owner");
         vm.prank(hacker);
-        registry.updateNode(APP_ID, node1, node2, TEE_URL_2);
+        registry.updateNode(APP_ID, node1, node2, TEE_URL_2, hex"", hex"");
+    }
+
+    // ─── per-node code override (composeHash/volumesHash) ─────────────────────
+
+    function test_AddNode_WithOverride_StoresPerNodeCode() public {
+        _register();
+        vm.prank(owner);
+        registry.addNode{value: MIN_STAKE}(
+            APP_ID, node2, TEE_URL_2, NODE_COMPOSE_OVERRIDE, NODE_VOLUMES_OVERRIDE
+        );
+
+        TappRegistry.NodeInfo memory n = registry.getNode(APP_ID, node2);
+        assertEq(n.composeHash, NODE_COMPOSE_OVERRIDE);
+        assertEq(n.volumesHash, NODE_VOLUMES_OVERRIDE);
+    }
+
+    function test_AddNode_EmptyOverride_InheritsAppDefault() public {
+        _register();
+        vm.prank(owner);
+        registry.addNode{value: MIN_STAKE}(APP_ID, node2, TEE_URL_2, hex"", hex"");
+
+        // Empty per-node override means "inherit the app-level default":
+        // the node carries no own code; the app-level COMPOSE_HASH/VOLUMES_HASH
+        // (in getAppInfo) remains authoritative.
+        TappRegistry.NodeInfo memory n = registry.getNode(APP_ID, node2);
+        assertEq(n.composeHash, hex"");
+        assertEq(n.volumesHash, hex"");
+    }
+
+    function test_RegisterApp_FirstNode_HasEmptyOverride() public {
+        _register();
+        // registerApp's first node inherits the app-level default => empty override.
+        TappRegistry.NodeInfo memory n = registry.getNode(APP_ID, node1);
+        assertEq(n.composeHash, hex"");
+        assertEq(n.volumesHash, hex"");
+    }
+
+    function test_UpdateNode_SetsPerNodeOverride() public {
+        _register();
+        vm.prank(owner);
+        registry.updateNode(
+            APP_ID, node1, node1, TEE_URL_1, NODE_COMPOSE_OVERRIDE, NODE_VOLUMES_OVERRIDE
+        );
+
+        TappRegistry.NodeInfo memory n = registry.getNode(APP_ID, node1);
+        assertEq(n.composeHash, NODE_COMPOSE_OVERRIDE);
+        assertEq(n.volumesHash, NODE_VOLUMES_OVERRIDE);
+    }
+
+    function test_UpdateNode_EmptyOverride_ClearsBackToInherit() public {
+        _register();
+        // First set an override...
+        vm.prank(owner);
+        registry.updateNode(
+            APP_ID, node1, node1, TEE_URL_1, NODE_COMPOSE_OVERRIDE, NODE_VOLUMES_OVERRIDE
+        );
+        assertEq(registry.getNode(APP_ID, node1).composeHash, NODE_COMPOSE_OVERRIDE);
+
+        // ...then clear it back to inherit (empty bytes).
+        vm.prank(owner);
+        registry.updateNode(APP_ID, node1, node1, TEE_URL_1, hex"", hex"");
+        TappRegistry.NodeInfo memory n = registry.getNode(APP_ID, node1);
+        assertEq(n.composeHash, hex"");
+        assertEq(n.volumesHash, hex"");
+    }
+
+    // ─── NodeCode event coverage ──────────────────────────────────────────────
+
+    function _findNodeCode(Vm.Log[] memory logs, address signer)
+        internal
+        pure
+        returns (bool found, bytes memory composeHash, bytes memory volumesHash)
+    {
+        bytes32 sig = keccak256("NodeCode(string,address,bytes,bytes)");
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].topics[0] == sig &&
+                logs[i].topics[2] == bytes32(uint256(uint160(signer)))) {
+                (composeHash, volumesHash) = abi.decode(logs[i].data, (bytes, bytes));
+                found = true;
+                break;
+            }
+        }
+    }
+
+    function test_RegisterApp_EmitsNodeCode_EmptyForFirstNode() public {
+        vm.recordLogs();
+        _register();
+
+        (bool found, bytes memory c, bytes memory v) =
+            _findNodeCode(vm.getRecordedLogs(), node1);
+        assertTrue(found, "NodeCode not emitted for first node");
+        assertEq(c, hex"");
+        assertEq(v, hex"");
+    }
+
+    function test_AddNode_EmitsNodeCode_WithOverride() public {
+        _register();
+
+        vm.recordLogs();
+        vm.prank(owner);
+        registry.addNode{value: MIN_STAKE}(
+            APP_ID, node2, TEE_URL_2, NODE_COMPOSE_OVERRIDE, NODE_VOLUMES_OVERRIDE
+        );
+
+        (bool found, bytes memory c, bytes memory v) =
+            _findNodeCode(vm.getRecordedLogs(), node2);
+        assertTrue(found, "NodeCode not emitted on addNode");
+        assertEq(c, NODE_COMPOSE_OVERRIDE);
+        assertEq(v, NODE_VOLUMES_OVERRIDE);
+    }
+
+    function test_UpdateNode_EmitsNodeCode_WithOverride() public {
+        _register();
+
+        vm.recordLogs();
+        vm.prank(owner);
+        registry.updateNode(
+            APP_ID, node1, node2, TEE_URL_2, NODE_COMPOSE_OVERRIDE, NODE_VOLUMES_OVERRIDE
+        );
+
+        (bool found, bytes memory c, bytes memory v) =
+            _findNodeCode(vm.getRecordedLogs(), node2);
+        assertTrue(found, "NodeCode not emitted on updateNode");
+        assertEq(c, NODE_COMPOSE_OVERRIDE);
+        assertEq(v, NODE_VOLUMES_OVERRIDE);
     }
 
     // ─── removeNode ───────────────────────────────────────────────────────────
@@ -544,6 +674,71 @@ contract TappRegistryTest is Test {
         assertTrue(registry.isAcknowledged(user, APP_ID));
     }
 
+    /// @notice Storage-compat for the per-node-override upgrade: register an app + a
+    ///         second node under the OLD impl (NodeInfo had no compose/volumes, addNode
+    ///         took none), upgrade the beacon to the NEW impl, and verify all old data
+    ///         still reads correctly and the appended per-node override fields default
+    ///         to empty (= inherit). Then exercise the new per-node override paths.
+    function test_Upgrade_FromV1_PreservesDataAndNodeOverrideDefaultsEmpty() public {
+        // 1. Deploy the OLD (V1) implementation behind its own beacon proxy.
+        TappRegistryV1 implV1 = new TappRegistryV1();
+        UpgradeableBeacon beacon = new UpgradeableBeacon(address(implV1), address(this));
+        bytes memory initData = abi.encodeCall(TappRegistryV1.initialize, (MIN_STAKE, LOCK_PERIOD));
+        BeaconProxy proxy = new BeaconProxy(address(beacon), initData);
+        TappRegistryV1 oldReg = TappRegistryV1(payable(address(proxy)));
+
+        // 2. Register an app + a second node using the OLD ABI (addNode had no compose/volumes).
+        vm.prank(owner);
+        oldReg.registerApp{value: MIN_STAKE}(APP_ID, COMPOSE_HASH, VOLUMES_HASH, imageHashes, node1, TEE_URL_1);
+        vm.prank(owner);
+        oldReg.addNode{value: MIN_STAKE}(APP_ID, node2, TEE_URL_2);
+
+        uint256 regAtBefore  = oldReg.getAppInfo(APP_ID).registeredAt;
+        uint256 node1AddedAt = oldReg.getNode(APP_ID, node1).addedAt;
+
+        // 3. Upgrade the beacon to the NEW implementation (same proxy/storage).
+        TappRegistry newImpl = new TappRegistry();
+        beacon.upgradeTo(address(newImpl));
+        TappRegistry reg = TappRegistry(payable(address(proxy)));
+
+        // 4a. App-level data preserved (AppInfo layout unchanged).
+        TappRegistry.AppInfo memory info = reg.getAppInfo(APP_ID);
+        assertEq(info.composeHash, COMPOSE_HASH);
+        assertEq(info.volumesHash, VOLUMES_HASH);
+        assertEq(info.imageHashes.length, imageHashes.length);
+        assertEq(info.imageHashes[0], imageHashes[0]);
+        assertEq(info.owner, owner);
+        assertEq(info.registeredAt, regAtBefore);
+
+        // 4b. Node list preserved.
+        address[] memory nodes = reg.getNodeList(APP_ID);
+        assertEq(nodes.length, 2);
+
+        // 4c. Old node fields preserved; appended override fields default to empty (= inherit).
+        TappRegistry.NodeInfo memory n1 = reg.getNode(APP_ID, node1);
+        assertEq(n1.teeUrl,      TEE_URL_1);
+        assertEq(n1.stakeAmount, MIN_STAKE);
+        assertEq(n1.addedAt,     node1AddedAt);
+        assertEq(n1.composeHash, hex"");
+        assertEq(n1.volumesHash, hex"");
+        TappRegistry.NodeInfo memory n2 = reg.getNode(APP_ID, node2);
+        assertEq(n2.teeUrl,      TEE_URL_2);
+        assertEq(n2.composeHash, hex"");
+        assertEq(n2.volumesHash, hex"");
+
+        // 5. New per-node override paths work on the upgraded proxy.
+        vm.prank(owner);
+        reg.updateNode(APP_ID, node1, node1, TEE_URL_1, NODE_COMPOSE_OVERRIDE, NODE_VOLUMES_OVERRIDE);
+        TappRegistry.NodeInfo memory n1b = reg.getNode(APP_ID, node1);
+        assertEq(n1b.composeHash, NODE_COMPOSE_OVERRIDE);
+        assertEq(n1b.volumesHash, NODE_VOLUMES_OVERRIDE);
+
+        address node3 = makeAddr("node3");
+        vm.prank(owner);
+        reg.addNode{value: MIN_STAKE}(APP_ID, node3, "https://node3", NODE_COMPOSE_OVERRIDE, NODE_VOLUMES_OVERRIDE);
+        assertEq(reg.getNode(APP_ID, node3).composeHash, NODE_COMPOSE_OVERRIDE);
+    }
+
     // ─── revokeAcknowledgement ────────────────────────────────────────────────
 
     function test_RevokeAcknowledgement_ClearsAck() public {
@@ -666,14 +861,14 @@ contract TappRegistryTest is Test {
         _register();
         vm.expectRevert("zero signer address");
         vm.prank(owner);
-        registry.addNode{value: MIN_STAKE}(APP_ID, address(0), TEE_URL_2);
+        registry.addNode{value: MIN_STAKE}(APP_ID, address(0), TEE_URL_2, hex"", hex"");
     }
 
     function test_UpdateNode_Revert_ZeroNewSigner() public {
         _register();
         vm.expectRevert("zero signer address");
         vm.prank(owner);
-        registry.updateNode(APP_ID, node1, address(0), TEE_URL_2);
+        registry.updateNode(APP_ID, node1, address(0), TEE_URL_2, hex"", hex"");
     }
 
     // ─── updateNode same-signer URL update ────────────────────────────────────
@@ -682,7 +877,7 @@ contract TappRegistryTest is Test {
         _register();
         string memory newUrl = "https://node1.new.example.com";
         vm.prank(owner);
-        registry.updateNode(APP_ID, node1, node1, newUrl);
+        registry.updateNode(APP_ID, node1, node1, newUrl, hex"", hex"");
 
         TappRegistry.NodeInfo memory n = registry.getNode(APP_ID, node1);
         assertEq(n.teeUrl,      newUrl);
@@ -700,7 +895,7 @@ contract TappRegistryTest is Test {
         assertTrue(registry.isAcknowledged(user, APP_ID));
 
         vm.prank(owner);
-        registry.updateNode(APP_ID, node1, node1, "https://changed");
+        registry.updateNode(APP_ID, node1, node1, "https://changed", hex"", hex"");
         assertFalse(registry.isAcknowledged(user, APP_ID));
     }
 

--- a/contract/test/fixtures/TappRegistryV1.sol
+++ b/contract/test/fixtures/TappRegistryV1.sol
@@ -9,11 +9,9 @@ pragma solidity ^0.8.24;
 ///         App model
 ///         ---------
 ///         Every app is logically a cluster. A "single-node app" is a cluster with
-///         one node. The app-level composeHash/volumesHash/imageHashes are the SHARED
-///         defaults for every node. A node MAY override composeHash/volumesHash in its
-///         NodeInfo (for node-specific config); the effective value for a node is its
-///         own override if non-empty, else the app-level default. imageHashes are
-///         always shared. registerApp always adds the first node atomically.
+///         one node. Shared code identity (composeHash, etc.) is at the app level;
+///         per-node differentiation (signerAddress, teeUrl) lives in NodeInfo.
+///         registerApp always adds the first node atomically.
 ///         When the last node is removed the app is automatically unregistered.
 ///
 ///         Staking
@@ -36,17 +34,16 @@ pragma solidity ^0.8.24;
 ///           3. Submit evidence to an RA service; confirm the returned signerAddress
 ///              and codeHash match on-chain values.
 ///           4. Call acknowledgeApp(appId) to record acknowledgement on-chain.
-contract TappRegistry {
+contract TappRegistryV1 {
 
     // ─── Structs ──────────────────────────────────────────────────────────────
 
     struct AppInfo {
-        /// @dev SHA384 of the docker-compose yaml — the SHARED DEFAULT for all nodes.
-        ///      A node may override this in NodeInfo; effective = node override ?? this.
+        /// @dev SHA384 of the normalised docker-compose yaml (shared by all nodes)
         bytes   composeHash;
-        /// @dev SHA384 of mount/volume files — shared default (see composeHash).
+        /// @dev SHA384 of all mount/volume files (shared by all nodes)
         bytes   volumesHash;
-        /// @dev Docker image digests, one per service in compose order (always shared)
+        /// @dev Docker image digests, one per service in compose order (shared)
         bytes[] imageHashes;
         address owner;
         uint256 registeredAt;
@@ -57,12 +54,6 @@ contract TappRegistry {
         string  teeUrl;
         uint256 addedAt;
         uint256 stakeAmount;
-        /// @dev OPTIONAL per-node override of the app-level composeHash. Empty means
-        ///      "inherit the app-level default". Appended after stakeAmount to keep the
-        ///      storage layout upgrade-compatible (existing nodes read empty = inherit).
-        bytes   composeHash;
-        /// @dev OPTIONAL per-node override of the app-level volumesHash (see composeHash).
-        bytes   volumesHash;
     }
 
     struct LockedEntry {
@@ -110,9 +101,6 @@ contract TappRegistry {
     event AppRegistered(string indexed appId, address indexed owner, bytes composeHash, bytes volumesHash, bytes[] imageHashes);
     event AppUpdated(string indexed appId, uint256 newAckVersion, bytes composeHash, bytes volumesHash, bytes[] imageHashes);
     event AppUnregistered(string indexed appId, address indexed owner);
-    /// @dev Per-node compose/volumes override (empty = inherit app-level). Emitted on
-    ///      node add and update (not remove).
-    event NodeCode(string indexed appId, address indexed signerAddress, bytes composeHash, bytes volumesHash);
     /// @dev oldSigner==0 means add, newSigner==0 means remove, both non-zero means replace.
     ///      stakeAmount and unlockAt are only set on add/remove; zero for replace.
     ///      newAckVersion is non-zero whenever the ack version was bumped by this call
@@ -191,12 +179,9 @@ contract TappRegistry {
 
     /// @notice Register a new app and add its first node atomically.
     ///         msg.value is the stake for the first node (>= minStakeAmount).
-    ///         composeHash/volumesHash are the app-level shared defaults; the first
-    ///         node inherits them (no override). Add divergent nodes via addNode with
-    ///         their own compose/volumes, or override later via updateNode.
     /// @param appId               Unique application identifier
-    /// @param composeHash         SHA384 of the docker-compose yaml (shared default)
-    /// @param volumesHash         SHA384 of all mount/volume files (shared default)
+    /// @param composeHash         SHA384 of the normalised docker-compose yaml
+    /// @param volumesHash         SHA384 of all mount/volume files
     /// @param imageHashes         Docker image digests, one per service in compose order
     /// @param firstSignerAddress  TEE EVM address of the first node
     /// @param firstTeeUrl         Evidence URL of the first node
@@ -220,15 +205,13 @@ contract TappRegistry {
         });
 
         ++_appAckVersions[appId];
-        // first node inherits the app-level defaults (empty per-node override).
-        _addNode(appId, firstSignerAddress, firstTeeUrl, "", "", msg.value, 0);
+        _addNode(appId, firstSignerAddress, firstTeeUrl, msg.value, 0);
 
         emit AppRegistered(appId, msg.sender, composeHash, volumesHash, imageHashes);
     }
 
-    /// @notice Update the app-level shared defaults (e.g. after re-deployment).
+    /// @notice Update the shared code metadata for an app (e.g. after re-deployment).
     ///         Increments ackVersion, invalidating all prior acknowledgements.
-    ///         Per-node overrides are updated separately via updateNode.
     function updateApp(
         string  calldata appId,
         bytes   calldata composeHash,
@@ -248,34 +231,29 @@ contract TappRegistry {
 
     /// @notice Add a node to an existing app. Only the app owner may add nodes.
     ///         msg.value is the stake for this node (>= minStakeAmount).
-    ///         composeHash/volumesHash are this node's OPTIONAL override — pass empty
-    ///         to inherit the app-level defaults. Increments ackVersion.
+    ///         Increments ackVersion because a new cluster member changes trust assumptions.
     function addNode(
         string  calldata appId,
         address          signerAddress,
-        string  calldata teeUrl,
-        bytes   calldata composeHash,
-        bytes   calldata volumesHash
+        string  calldata teeUrl
     ) external payable onlyAppOwner(appId) {
         require(msg.value >= minStakeAmount, "insufficient stake");
         require(_nodes[appId][signerAddress].addedAt == 0, "node already exists");
 
         uint256 newVersion = ++_appAckVersions[appId];
-        _addNode(appId, signerAddress, teeUrl, composeHash, volumesHash, msg.value, newVersion);
+        _addNode(appId, signerAddress, teeUrl, msg.value, newVersion);
     }
 
-    /// @notice Update a node's signer address, teeUrl, and/or code identity
-    ///         (composeHash/volumesHash). Requires the old node to exist; applies new
-    ///         values unconditionally. Stake carries over. Always increments ackVersion.
-    ///         Pass newSigner == oldSigner to keep the signer and update the rest.
+    /// @notice Update a node's signer address and/or teeUrl.
+    ///         Requires the old node to exist; applies new values unconditionally.
+    ///         Stake carries over. Always increments ackVersion.
+    ///         Pass newSigner == oldSigner to update only the teeUrl.
     ///         Only the app owner may call this.
     function updateNode(
         string  calldata appId,
         address          oldSigner,
         address          newSigner,
-        string  calldata teeUrl,
-        bytes   calldata composeHash,
-        bytes   calldata volumesHash
+        string  calldata teeUrl
     ) external onlyAppOwner(appId) {
         require(newSigner != address(0), "zero signer address");
         require(_nodes[appId][oldSigner].addedAt != 0, "old node not found");
@@ -293,17 +271,10 @@ contract TappRegistry {
             }
             delete _nodes[appId][oldSigner];
         }
-        _nodes[appId][newSigner] = NodeInfo({
-            teeUrl:      teeUrl,
-            addedAt:     block.timestamp,
-            stakeAmount: stake,
-            composeHash: composeHash,
-            volumesHash: volumesHash
-        });
+        _nodes[appId][newSigner] = NodeInfo({teeUrl: teeUrl, addedAt: block.timestamp, stakeAmount: stake});
 
         uint256 newVersion = ++_appAckVersions[appId];
         emit NodeUpdated(appId, oldSigner, newSigner, 0, 0, newVersion);
-        emit NodeCode(appId, newSigner, composeHash, volumesHash);
     }
 
     /// @notice Remove a node. Stake is locked for lockPeriod seconds in the owner's
@@ -529,8 +500,6 @@ contract TappRegistry {
         string  memory appId,
         address        signerAddress,
         string  memory teeUrl,
-        bytes   memory composeHash,
-        bytes   memory volumesHash,
         uint256        stakeAmount,
         uint256        newAckVersion
     ) internal {
@@ -538,13 +507,10 @@ contract TappRegistry {
         _nodes[appId][signerAddress] = NodeInfo({
             teeUrl:      teeUrl,
             addedAt:     block.timestamp,
-            stakeAmount: stakeAmount,
-            composeHash: composeHash,
-            volumesHash: volumesHash
+            stakeAmount: stakeAmount
         });
         _nodeList[appId].push(signerAddress);
 
         emit NodeUpdated(appId, address(0), signerAddress, stakeAmount, 0, newAckVersion);
-        emit NodeCode(appId, signerAddress, composeHash, volumesHash);
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1713,6 +1713,23 @@ async fn fetch_app_hashes(
     Ok((compose_hash, volumes_hash, image_hashes))
 }
 
+/// Decide the per-node override to store on-chain: compare the node's own
+/// (compose, volumes) against the app-level defaults read from chain and return empty
+/// for whichever matches (so the node inherits the default and follows updateApp).
+async fn node_override_hashes(
+    rpc_url: &str,
+    contract: &str,
+    app_id: &str,
+    node_compose: Vec<u8>,
+    node_volumes: Vec<u8>,
+) -> Result<(Vec<u8>, Vec<u8>), Box<dyn std::error::Error>> {
+    let (app_compose, app_volumes) =
+        tapp_service::onchain::get_app_default_hashes(rpc_url, contract, app_id).await?;
+    let compose = if node_compose == app_compose { Vec::new() } else { node_compose };
+    let volumes = if node_volumes == app_volumes { Vec::new() } else { node_volumes };
+    Ok((compose, volumes))
+}
+
 async fn register_onchain(
     server: &str,
     app_id: String,
@@ -1728,6 +1745,7 @@ async fn register_onchain(
     let signer_address = fetch_signer_address(server, &app_id).await?;
 
     let params = OnchainParams { rpc_url, contract, private_key };
+    // compose/volumes become the app-level shared defaults; the first node inherits them.
     let tx = tapp_service::onchain::register_app(
         &params,
         &app_id,
@@ -1757,6 +1775,8 @@ async fn update_onchain(
 ) -> Result<(), Box<dyn std::error::Error>> {
     use tapp_service::onchain::OnchainParams;
 
+    // updates the app-level shared defaults (compose/volumes/images); per-node
+    // overrides are updated via update-node-onchain.
     let (compose_hash, volumes_hash, image_hashes) = fetch_app_hashes(server, &app_id).await?;
 
     let params = OnchainParams { rpc_url, contract, private_key };
@@ -1792,8 +1812,18 @@ async fn add_node_onchain(
         (fetched, tee_url_arg.unwrap_or_else(|| server.to_string()))
     };
 
+    // This node's own compose/volumes (fetched from the node being added). Store a
+    // per-node override only when it differs from the app-level default; otherwise
+    // pass empty so the node inherits the default (and follows future updateApp).
+    let (node_compose, node_volumes, _image_hashes) = fetch_app_hashes(server, &app_id).await?;
+    let (compose_hash, volumes_hash) =
+        node_override_hashes(&rpc_url, &contract, &app_id, node_compose, node_volumes).await?;
+
     let params = OnchainParams { rpc_url, contract, private_key };
-    let tx = tapp_service::onchain::add_node(&params, &app_id, signer, &tee_url, U256::from(stake_wei)).await?;
+    let tx = tapp_service::onchain::add_node(
+        &params, &app_id, signer, &tee_url, compose_hash, volumes_hash, U256::from(stake_wei),
+    )
+    .await?;
 
     println!("✓ Node added on-chain");
     println!("  App ID: {}", app_id);
@@ -1861,8 +1891,17 @@ async fn update_node_onchain(
         (fetched, tee_url_arg.unwrap_or_else(|| server.to_string()))
     };
 
+    // refresh this node's compose/volumes from its server; store as a per-node override
+    // only when it differs from the app-level default (else empty = inherit).
+    let (node_compose, node_volumes, _image_hashes) = fetch_app_hashes(server, &app_id).await?;
+    let (compose_hash, volumes_hash) =
+        node_override_hashes(&rpc_url, &contract, &app_id, node_compose, node_volumes).await?;
+
     let params = OnchainParams { rpc_url, contract, private_key };
-    let tx = tapp_service::onchain::update_node(&params, &app_id, old_signer_addr, new_signer, tee_url.clone()).await?;
+    let tx = tapp_service::onchain::update_node(
+        &params, &app_id, old_signer_addr, new_signer, tee_url.clone(), compose_hash, volumes_hash,
+    )
+    .await?;
 
     println!("✓ Node updated on-chain");
     println!("  App ID: {}", app_id);

--- a/src/onchain.rs
+++ b/src/onchain.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Result};
 use ethers::{
-    abi::{encode, Token},
+    abi::{decode, encode, ParamType, Token},
     prelude::*,
     providers::{Http, Provider},
     types::{Address, Bytes, TransactionRequest, U256},
@@ -19,6 +19,50 @@ fn calldata(sig: &str, tokens: Vec<Token>) -> Vec<u8> {
     let mut data = selector(sig).to_vec();
     data.extend_from_slice(&encode(&tokens));
     data
+}
+
+// ─── Reads ──────────────────────────────────────────────────────────────────
+
+/// Read the app-level default (composeHash, volumesHash) via getAppInfo(string).
+/// Used to decide whether a node needs a per-node override (differs from default)
+/// or should inherit (equals default → store empty).
+pub async fn get_app_default_hashes(
+    rpc_url: &str,
+    contract: &str,
+    app_id: &str,
+) -> Result<(Vec<u8>, Vec<u8>)> {
+    let provider =
+        Provider::<Http>::try_from(rpc_url).map_err(|e| anyhow!("Invalid RPC URL: {}", e))?;
+    let to = Address::from_str(contract).map_err(|_| anyhow!("Invalid contract address"))?;
+    let data = calldata("getAppInfo(string)", vec![Token::String(app_id.to_owned())]);
+    let tx = TransactionRequest::new().to(to).data(Bytes::from(data));
+    let out = provider
+        .call(&tx.into(), None)
+        .await
+        .map_err(|e| anyhow!("getAppInfo call failed: {}", e))?;
+
+    // AppInfo = (bytes composeHash, bytes volumesHash, bytes[] imageHashes, address owner, uint256 registeredAt)
+    let tuple = ParamType::Tuple(vec![
+        ParamType::Bytes,
+        ParamType::Bytes,
+        ParamType::Array(Box::new(ParamType::Bytes)),
+        ParamType::Address,
+        ParamType::Uint(256),
+    ]);
+    let tokens = decode(&[tuple], &out).map_err(|e| anyhow!("decode getAppInfo: {}", e))?;
+    if let Some(Token::Tuple(fields)) = tokens.into_iter().next() {
+        let compose = match &fields[0] {
+            Token::Bytes(b) => b.clone(),
+            _ => vec![],
+        };
+        let volumes = match &fields[1] {
+            Token::Bytes(b) => b.clone(),
+            _ => vec![],
+        };
+        Ok((compose, volumes))
+    } else {
+        Err(anyhow!("unexpected getAppInfo return shape"))
+    }
 }
 
 // ─── Transaction sender ───────────────────────────────────────────────────────
@@ -176,6 +220,7 @@ impl OnchainParams {
 }
 
 /// registerApp(string,bytes,bytes,bytes[],address,string)
+/// compose/volumes are the app-level shared defaults; the first node inherits them.
 pub async fn register_app(
     params: &OnchainParams,
     app_id: &str,
@@ -200,7 +245,8 @@ pub async fn register_app(
     send_tx(&params.rpc_url, &params.private_key, params.contract_address()?, data, stake_wei).await
 }
 
-/// updateApp(string,bytes,bytes,bytes[])
+/// updateApp(string,bytes,bytes,bytes[]) — updates the app-level shared defaults.
+/// Per-node overrides are updated via update_node.
 pub async fn update_app(
     params: &OnchainParams,
     app_id: &str,
@@ -220,40 +266,48 @@ pub async fn update_app(
     send_tx(&params.rpc_url, &params.private_key, params.contract_address()?, data, U256::zero()).await
 }
 
-/// addNode(string,address,string)
+/// addNode(string,address,string,bytes,bytes)
 pub async fn add_node(
     params: &OnchainParams,
     app_id: &str,
     signer_address: Address,
     tee_url: &str,
+    compose_hash: Vec<u8>,
+    volumes_hash: Vec<u8>,
     stake_wei: U256,
 ) -> Result<TxHash> {
     let data = calldata(
-        "addNode(string,address,string)",
+        "addNode(string,address,string,bytes,bytes)",
         vec![
             Token::String(app_id.to_owned()),
             Token::Address(signer_address),
             Token::String(tee_url.to_owned()),
+            Token::Bytes(compose_hash),
+            Token::Bytes(volumes_hash),
         ],
     );
     send_tx(&params.rpc_url, &params.private_key, params.contract_address()?, data, stake_wei).await
 }
 
-/// updateNode(string,address,address,string)
+/// updateNode(string,address,address,string,bytes,bytes)
 pub async fn update_node(
     params: &OnchainParams,
     app_id: &str,
     old_signer: Address,
     new_signer: Address,
     tee_url: String,
+    compose_hash: Vec<u8>,
+    volumes_hash: Vec<u8>,
 ) -> Result<TxHash> {
     let data = calldata(
-        "updateNode(string,address,address,string)",
+        "updateNode(string,address,address,string,bytes,bytes)",
         vec![
             Token::String(app_id.to_owned()),
             Token::Address(old_signer),
             Token::Address(new_signer),
             Token::String(tee_url),
+            Token::Bytes(compose_hash),
+            Token::Bytes(volumes_hash),
         ],
     );
     send_tx(&params.rpc_url, &params.private_key, params.contract_address()?, data, U256::zero()).await


### PR DESCRIPTION
## Why
`composeHash`/`volumesHash` were app-level (shared by all nodes), which can't represent apps whose nodes run **node-specific config** — e.g. `0g-kms`'s three nodes use `kms.toml` / `kms-node3.toml` → different compose per node (same image). Closes #535.

## What — model: app-level shared default + optional per-node override
- `AppInfo.composeHash/volumesHash` stay as the **shared default**; `imageHashes` stay shared.
- `NodeInfo` gains optional `composeHash/volumesHash` (override; empty = inherit).
- **Effective** value for a node = its override if non-empty, else the app-level default.
- `getNode` **resolves** this on read (substitutes the default for an empty override), so every consumer — `cast`, explorers, indexers, SDK — gets the usable value from one call. Storage keeps empty = inherit; the raw override is observable via the new **`NodeCode`** event.
- CLI `add-node-onchain`/`update-node-onchain` store a per-node override **only when it differs** from the app-level default (else empty = inherit, so the node follows future `updateApp`). `register`/`update-onchain` set the app-level defaults.

## Upgrade-safe (no redeploy / no migration)
`AppInfo` is unchanged; `NodeInfo` **appends** the two fields. Existing nodes read empty = inherit → fall back to the app-level default they already have. Proven by a `TappRegistryV1` (old impl) → new-impl beacon-upgrade test asserting old data still reads and inherited nodes resolve to the default.

## Verification
- **forge: 73 passed** (incl. upgrade-compat + inherit/override + `NodeCode`).
- `cargo build` / `go build` pass (Go ABI/bindings are gitignored generated artifacts — regenerate with `go run ./cmd/compile/` + abigen after merge).
- **Testnet e2e** on a fresh, source-verified instance (`0x2Ce80374318B1d7Fb3345724457a182E0ad165c9`): register (app default + first node inherit), add-node (divergent override), update-node (refresh / clear-to-inherit), and post-upgrade `getNode` resolving inherit→default — all confirmed on-chain.

## Follow-ups (separate)
- Tapp verification **SDK** to encapsulate chain reads + evidence parse + AS client (draft: `docs/TAPP_SDK_DESIGN.md`).
- Pre-existing CLI `-s` short-flag collision (`--stake-wei` vs global `--server`) — debug builds panic at startup; fix separately.
- `verify_app.py` (other branch) should compare against the node's effective compose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)