### PR TITLE
feat: list apps on a server (ListApps RPC + tapp-cli list-apps)

### DIFF
--- a/proto/tapp_service.proto
+++ b/proto/tapp_service.proto
@@ -29,6 +29,9 @@ service TappService {
   // Get application information
   rpc GetAppInfo(GetAppInfoRequest) returns (GetAppInfoResponse);
 
+  // List all apps currently on the server
+  rpc ListApps(ListAppsRequest) returns (ListAppsResponse);
+
   // Get TAPP service configuration
   rpc GetTappInfo(GetTappInfoRequest) returns (GetTappInfoResponse);
 
@@ -267,6 +270,21 @@ message GetAppInfoResponse {
   map<string, string> volumes_hash = 6;  // Map: file_name -> hash
   string compose_content = 7;
   map<string, string> image_hash = 9;  // Map: service_name -> image_hash
+}
+
+// List Apps Messages
+message ListAppsRequest {}
+
+message AppSummary {
+  string app_id = 1;
+  string owner = 2;
+  string compose_hash = 3;
+  uint32 image_count = 4;  // number of service images in the compose
+}
+
+message ListAppsResponse {
+  bool success = 1;
+  repeated AppSummary apps = 2;
 }
 
 // Get TAPP Info Messages

--- a/src/auth_layer.rs
+++ b/src/auth_layer.rs
@@ -203,8 +203,10 @@ enum MethodPermission {
 fn get_method_permission(method_name: &str) -> MethodPermission {
     match method_name {
         // Public methods (no authentication required)
-        "GetEvidence" | "GetAppKey" | "GetAppInfo" | "GetTaskStatus" | "GetServiceStatus"
-        | "GetAppSecretKey" | "GetTappInfo" | "GetSecretResource" => MethodPermission::Public,
+        "GetEvidence" | "GetAppKey" | "GetAppInfo" | "ListApps" | "GetTaskStatus"
+        | "GetServiceStatus" | "GetAppSecretKey" | "GetTappInfo" | "GetSecretResource" => {
+            MethodPermission::Public
+        }
 
         // Owner-only methods
         "StartApp"

--- a/src/boot/mod.rs
+++ b/src/boot/mod.rs
@@ -660,6 +660,23 @@ enable_eventlog = true
         Ok(app_info.get(app_id).cloned())
     }
 
+    /// Summaries of all apps currently running on this server:
+    /// (app_id, owner, compose_hash, image_count).
+    pub async fn list_apps(&self) -> Vec<(String, String, String, usize)> {
+        let app_info = self.app_info.lock().await;
+        app_info
+            .values()
+            .map(|a| {
+                (
+                    a.app_id.clone(),
+                    a.owner.clone(),
+                    a.compose_content.hash.clone(),
+                    a.compose_content.image_hash.len(),
+                )
+            })
+            .collect()
+    }
+
     /// Docker login to registry for pulling private images
     pub async fn docker_login(
         &self,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,7 +5,7 @@ use tapp_service::proto::{
     DockerLogoutRequest, GetAppContainerStatusRequest, GetAppInfoRequest, GetAppKeyRequest,
     GetAppLogsRequest, GetAppSecretKeyRequest, GetEvidenceRequest, GetSecretResourceRequest,
     GetServiceLogsRequest, GetServiceStatusRequest, GetTappInfoRequest, GetTaskStatusRequest,
-    ListWhitelistRequest, MountFile, PruneImagesRequest, RemoveFromWhitelistRequest,
+    ListAppsRequest, ListWhitelistRequest, MountFile, PruneImagesRequest, RemoveFromWhitelistRequest,
     StartAppRequest, StartServiceRequest, StopAppRequest, StopServiceRequest, WithdrawBalanceRequest,
 };
 use tonic::{metadata::MetadataValue, Request};
@@ -63,6 +63,9 @@ enum Commands {
         #[arg(short, long)]
         app_id: String,
     },
+
+    /// List all apps currently on the server
+    ListApps,
 
     /// Get application logs
     GetAppLogs {
@@ -468,6 +471,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         Commands::GetAppInfo { app_id } => {
             get_app_info(&cli.server, app_id).await?;
+        }
+        Commands::ListApps => {
+            list_apps(&cli.server).await?;
         }
         Commands::GetAppLogs {
             app_id,
@@ -973,6 +979,33 @@ async fn get_app_info(server: &str, app_id: String) -> Result<(), Box<dyn std::e
     println!("  Compose Hash: {}", result.compose_hash);
     println!("  Volumes Hash: {:?}", result.volumes_hash);
     println!("  Image Hash: {:?}", result.image_hash);
+
+    Ok(())
+}
+
+async fn list_apps(server: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let mut client = TappServiceClient::connect(server.to_string()).await?;
+
+    let response = client.list_apps(Request::new(ListAppsRequest {})).await?;
+    let result = response.into_inner();
+
+    if result.apps.is_empty() {
+        println!("No apps on this server.");
+        return Ok(());
+    }
+
+    println!("Apps ({}):", result.apps.len());
+    for a in &result.apps {
+        let compose = if a.compose_hash.len() > 16 {
+            format!("{}…", &a.compose_hash[..16])
+        } else {
+            a.compose_hash.clone()
+        };
+        println!(
+            "  {}\n    owner={}  compose={}  images={}",
+            a.app_id, a.owner, compose, a.image_count
+        );
+    }
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -572,6 +572,30 @@ impl TappService for TappServiceImpl {
         }))
     }
 
+    async fn list_apps(
+        &self,
+        _request: Request<ListAppsRequest>,
+    ) -> Result<Response<ListAppsResponse>, Status> {
+        info!("Calling ListApps");
+        let apps = self
+            .boot_service
+            .list_apps()
+            .await
+            .into_iter()
+            .map(|(app_id, owner, compose_hash, image_count)| AppSummary {
+                app_id,
+                owner,
+                compose_hash,
+                image_count: image_count as u32,
+            })
+            .collect();
+
+        Ok(Response::new(ListAppsResponse {
+            success: true,
+            apps,
+        }))
+    }
+
     async fn get_tapp_info(
         &self,
         _request: Request<GetTappInfoRequest>,


### PR DESCRIPTION
## Why
There was no way to enumerate the apps currently on a tapp server — you had to already know an `app_id` (this bit us repeatedly when probing servers).

## What
- **proto**: `ListApps` RPC + `ListAppsRequest` / `AppSummary` / `ListAppsResponse`.
- **server**: `BootService::list_apps()` summarizes the in-memory `app_info` map; `list_apps` handler returns `{app_id, owner, compose_hash, image_count}` per app. `auth_layer` marks `ListApps` **Public** (read-only, like `GetAppInfo`).
- **cli**: `tapp-cli list-apps`.

## Verification
Built clean; ran a local server and confirmed `tapp-cli list-apps` returns the app set **without a signature** (Public), exercising RPC wiring + auth bypass + handler. Non-empty listing is a straight map iteration (seen at deploy time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)