### PR TITLE
fix(cli): resolve clap short-flag collisions (-s/-k/-c/-r)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -75,7 +75,7 @@ enum Commands {
         lines: i32,
 
         /// Specific service name
-        #[arg(short, long)]
+        #[arg(long)]
         service: Option<String>,
     },
 
@@ -137,7 +137,7 @@ enum Commands {
         app_id: String,
 
         /// Service name
-        #[arg(short, long)]
+        #[arg(long)]
         service_name: String,
 
         /// Pull latest image before starting
@@ -152,7 +152,7 @@ enum Commands {
         app_id: String,
 
         /// Service name
-        #[arg(short, long)]
+        #[arg(long)]
         service_name: String,
     },
 
@@ -238,11 +238,11 @@ enum Commands {
         rpc_url: String,
 
         /// Chain ID
-        #[arg(short, long)]
+        #[arg(long)]
         chain_id: u64,
 
         /// Custom recipient address (defaults to tapp owner)
-        #[arg(short = 'r', long)]
+        #[arg(long)]
         recipient: Option<String>,
     },
 
@@ -268,7 +268,7 @@ enum Commands {
         message: String,
 
         /// Signature (hex)
-        #[arg(short, long)]
+        #[arg(long)]
         signature: String,
     },
 
@@ -290,7 +290,7 @@ enum Commands {
         contract: String,
 
         /// Stake amount in wei (must be >= minStakeAmount)
-        #[arg(short, long)]
+        #[arg(long)]
         stake_wei: u128,
     },
 
@@ -326,7 +326,7 @@ enum Commands {
         contract: String,
 
         /// Stake amount in wei (must be >= minStakeAmount)
-        #[arg(short, long)]
+        #[arg(long)]
         stake_wei: u128,
 
         /// Signer address of the new node (optional; fetched from --server if not set)


### PR DESCRIPTION
## Problem
Several `tapp-cli` subcommand args used `#[arg(short, long)]`, auto-deriving a short flag that collided with the global `--server` (`-s`) or another arg in the same command. clap's debug assert **panics at startup** — e.g. `register-onchain` could not run at all in a debug build; release builds parsed `-s` ambiguously. (Documented in #7; this fixes the code.)

## Fix
Drop the colliding shorts (keep the `--long` forms, which all docs/examples already use — so no working usage changes):
- `service`, `service_name`, `signature`, `chain_id`, `stake_wei` — auto-derived `-s`/`-c` clashing with `--server`/`--contract`.
- `recipient` — explicit `-r` clashing with `--rpc-url` in `withdraw-balance`.

## Verification
Built debug and ran `--help` on **every** subcommand — none panic (previously `register-onchain` and `withdraw-balance` did).

🤖 Generated with [Claude Code](https://claude.com/claude-code)