### PR TITLE
feat(cli): verify-app — end-to-end app verification (chain → evidence → AS → reconcile)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -8,5 +8,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .file_descriptor_set_path(out_dir.join("tapp_service_descriptor.bin"))
         .compile_protos(&["proto/tapp_service.proto"], &["proto"])?;
 
+    // CoCo Attestation Service (gRPC :50004) client, used by verify-app.
+    tonic_build::configure().compile_protos(&["proto/attestation.proto"], &["proto"])?;
+
     Ok(())
 }

--- a/proto/attestation.proto
+++ b/proto/attestation.proto
@@ -1,0 +1,98 @@
+syntax = "proto3";
+
+package attestation;
+
+message AttestationRequest {
+    // The evidence from one or more atttesters that should be verified
+    // along with metadata about the evidence.
+    repeated IndividualAttestationRequest verification_requests = 1;
+    // List of IDs of the policy used to check evidence. If not provided,
+    // a "default" one will be used.
+    // EAR tokens will be based only on the first policy specified in
+    // this list.
+    repeated string policy_ids = 2;
+
+}
+
+message IndividualAttestationRequest {
+    // TEE enum. Specify the evidence type
+    string tee = 1;
+
+    // Base64 encoded evidence. The alphabet is URL_SAFE_NO_PAD.
+    // defined in https://datatracker.ietf.org/doc/html/rfc4648#section-5
+    string evidence = 3;
+
+    // Runtime Data used to check the binding relationship with report data in
+    // Evidence
+    oneof runtime_data {
+        // Base64 encoded runtime data slice. The whole string will be base64
+        // decoded. The result one will then be accumulated into a digest which
+        // is used as the expected runtime data to check against the one inside
+        // evidence.
+        //
+        // The alphabet is URL_SAFE_NO_PAD.
+        // defined in https://datatracker.ietf.org/doc/html/rfc4648#section-5
+        string raw_runtime_data = 4;
+
+        // Runtime data in a JSON map. CoCoAS will rearrange each layer of the
+        // data JSON object in dictionary order by key, then serialize and output
+        // it into a compact string, and perform hash calculation on the whole
+        // to check against the one inside evidence.
+        //
+        // After the verification, the structured runtime data field will be included
+        // inside the token claims.
+        string structured_runtime_data = 5;
+    }
+
+    // Init Data used to check the binding relationship with init data in
+    // Evidence
+    oneof init_data {
+        // Base64 encoded init data digest slice. The whole string will be base64
+        // decoded. The result one will then be accumulated into a digest which
+        // is used as the expected init data to check against the one inside
+        // evidence.
+        //
+        // The alphabet is URL_SAFE_NO_PAD.
+        // defined in https://datatracker.ietf.org/doc/html/rfc4648#section-5
+        string init_data_digest = 6;
+
+        // Init data TOML. CoCoAS will perform hash calculation on the whole
+        // to check against the one inside evidence. The hash algorithm to use
+        // is inside the Initdata Toml's metadata.
+        // 
+        // See https://github.com/confidential-containers/trustee/blob/main/kbs/docs/initdata.md#toml-version
+        // 
+        // After the verification, the `.data` field of init data field will
+        // be included inside the token claims.
+        string init_data_toml = 7;
+    }
+
+    // Hash algorithm used to calculate runtime data. Currently can be "sha256",
+    // "sha384" or "sha512". If not specified, "sha384" will be selected.
+    string runtime_data_hash_algorithm = 8;
+}
+
+message AttestationResponse {
+    string attestation_token = 1;
+}
+
+message SetPolicyRequest {
+    string policy_id = 1;
+    string policy = 2;
+}
+message SetPolicyResponse {}
+
+message ChallengeRequest {
+    // ChallengeRequest uses HashMap to pass variables like:
+    // tee, tee_params etc
+    map<string, string> inner = 1;
+}
+message ChallengeResponse {
+    string attestation_challenge = 1;
+}
+
+service AttestationService {
+    rpc AttestationEvaluate(AttestationRequest) returns (AttestationResponse) {};
+    rpc SetAttestationPolicy(SetPolicyRequest) returns (SetPolicyResponse) {};
+    rpc GetAttestationChallenge(ChallengeRequest) returns (ChallengeResponse) {};
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -64,6 +64,23 @@ enum Commands {
         app_id: String,
     },
 
+    /// Verify an app end-to-end: read on-chain registry, fetch evidence from each
+    /// node, verify the quote via CoCo-AS, and reconcile evidence against the chain
+    VerifyApp {
+        /// Application ID
+        #[arg(long)]
+        app_id: String,
+        /// EVM RPC URL
+        #[arg(long)]
+        rpc_url: String,
+        /// TappRegistry contract address (0x...)
+        #[arg(long)]
+        contract: String,
+        /// CoCo Attestation Service gRPC endpoint (host:port)
+        #[arg(long, default_value = "47.237.201.184:50004")]
+        as_endpoint: String,
+    },
+
     /// Get application logs
     GetAppLogs {
         /// Application ID
@@ -468,6 +485,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         Commands::GetAppInfo { app_id } => {
             get_app_info(&cli.server, app_id).await?;
+        }
+        Commands::VerifyApp { app_id, rpc_url, contract, as_endpoint } => {
+            verify_app_cmd(&app_id, &rpc_url, &contract, &as_endpoint).await?;
         }
         Commands::GetAppLogs {
             app_id,
@@ -974,6 +994,49 @@ async fn get_app_info(server: &str, app_id: String) -> Result<(), Box<dyn std::e
     println!("  Volumes Hash: {:?}", result.volumes_hash);
     println!("  Image Hash: {:?}", result.image_hash);
 
+    Ok(())
+}
+
+async fn verify_app_cmd(
+    app_id: &str,
+    rpc_url: &str,
+    contract: &str,
+    as_endpoint: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let verdict = tapp_service::verify::verify_app(rpc_url, contract, app_id, as_endpoint).await?;
+
+    let yn = |b: bool| if b { "✓" } else { "✗" };
+    println!("Verifying app: {}  ({} node(s))", verdict.app_id, verdict.nodes.len());
+    let mut all_ok = true;
+    for n in &verdict.nodes {
+        let reconciled = n.reconciled();
+        let quote_ok = n.ear_status == "affirming";
+        all_ok &= reconciled;
+        println!("\n  node {}", n.signer);
+        println!("    teeUrl     : {}", n.tee_url);
+        if !n.reachable {
+            println!("    ✗ unreachable / {}", n.note);
+            all_ok = false;
+            continue;
+        }
+        println!(
+            "    AS         : ear.status={} tcb_status={} advisories={}",
+            n.ear_status, n.tcb_status, n.advisories
+        );
+        println!(
+            "    reconcile  : signer{} compose{} volumes{} image{}",
+            yn(n.signer_ok), yn(n.compose_ok), yn(n.volumes_ok), yn(n.image_ok)
+        );
+        if !n.note.is_empty() {
+            println!("    note       : {}", n.note);
+        }
+        println!(
+            "    => reconcile {} ; quote {}",
+            if reconciled { "PASS" } else { "FAIL" },
+            if quote_ok { "trusted".to_string() } else { format!("untrusted ({}/{})", n.ear_status, n.tcb_status) }
+        );
+    }
+    println!("\nResult: reconciliation {}", if all_ok { "ALL PASS ✅" } else { "has failures ❌" });
     Ok(())
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -64,18 +64,20 @@ enum Commands {
         app_id: String,
     },
 
-    /// Verify an app end-to-end: read on-chain registry, fetch evidence from each
-    /// node, verify the quote via CoCo-AS, and reconcile evidence against the chain
+    /// Verify an app. Chain mode (with --contract + --rpc-url): discover nodes on-chain,
+    /// fetch each node's evidence, verify the quote via CoCo-AS, and reconcile against the
+    /// chain. Direct mode (no --contract, uses --server): verify one node's evidence + quote
+    /// and show what it attests, without on-chain reconciliation (for un-registered apps).
     VerifyApp {
         /// Application ID
         #[arg(long)]
         app_id: String,
-        /// EVM RPC URL
+        /// EVM RPC URL (chain mode)
         #[arg(long)]
-        rpc_url: String,
-        /// TappRegistry contract address (0x...)
+        rpc_url: Option<String>,
+        /// TappRegistry contract address 0x… (chain mode)
         #[arg(long)]
-        contract: String,
+        contract: Option<String>,
         /// CoCo Attestation Service gRPC endpoint (host:port)
         #[arg(long, default_value = "47.237.201.184:50004")]
         as_endpoint: String,
@@ -487,7 +489,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             get_app_info(&cli.server, app_id).await?;
         }
         Commands::VerifyApp { app_id, rpc_url, contract, as_endpoint } => {
-            verify_app_cmd(&app_id, &rpc_url, &contract, &as_endpoint).await?;
+            verify_app_cmd(&cli.server, &app_id, rpc_url, contract, &as_endpoint).await?;
         }
         Commands::GetAppLogs {
             app_id,
@@ -998,12 +1000,38 @@ async fn get_app_info(server: &str, app_id: String) -> Result<(), Box<dyn std::e
 }
 
 async fn verify_app_cmd(
+    server: &str,
     app_id: &str,
-    rpc_url: &str,
-    contract: &str,
+    rpc_url: Option<String>,
+    contract: Option<String>,
     as_endpoint: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let verdict = tapp_service::verify::verify_app(rpc_url, contract, app_id, as_endpoint).await?;
+    // Direct mode: no --contract → verify the single --server node without chain reconciliation.
+    if contract.is_none() {
+        let d = tapp_service::verify::verify_node_direct(server, app_id, as_endpoint).await?;
+        let quote_ok = d.ear_status == "affirming";
+        println!("Verifying app: {}  (direct mode — no on-chain reconciliation)", app_id);
+        println!("  server      : {}", d.server);
+        println!("  signer      : {}  (attested in report_data)", d.signer);
+        println!("  AS          : ear.status={} tcb_status={} advisories={}", d.ear_status, d.tcb_status, d.advisories);
+        if !d.compose_hash.is_empty() {
+            println!("  compose     : {}", d.compose_hash);
+        }
+        if !d.images.is_empty() {
+            println!("  images      : {:?}", d.images);
+        }
+        if !d.note.is_empty() {
+            println!("  note        : {}", d.note);
+        }
+        println!("\nQuote {}", if quote_ok { "trusted ✅".to_string() } else { format!("untrusted ⚠️ ({}/{})", d.ear_status, d.tcb_status) });
+        println!("(direct mode shows what the node attests; register on-chain + use --contract to reconcile)");
+        return Ok(());
+    }
+
+    // Chain mode.
+    let rpc_url = rpc_url.ok_or("chain mode requires --rpc-url (or omit --contract for direct mode)")?;
+    let contract = contract.unwrap();
+    let verdict = tapp_service::verify::verify_app(&rpc_url, &contract, app_id, as_endpoint).await?;
 
     let yn = |b: bool| if b { "✓" } else { "✗" };
     println!("Verifying app: {}  ({} node(s))", verdict.app_id, verdict.nodes.len());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod service_monitor;
 pub mod signature_auth;
 pub mod task_manager;
 pub mod utils;
+pub mod verify;
 pub use boot::BootService;
 pub use config::TappConfig;
 pub use error::{TappError, TappResult};

--- a/src/onchain.rs
+++ b/src/onchain.rs
@@ -65,6 +65,106 @@ pub async fn get_app_default_hashes(
     }
 }
 
+/// Low-level eth_call helper returning raw return bytes.
+async fn call_raw(rpc_url: &str, contract: &str, data: Vec<u8>) -> Result<Vec<u8>> {
+    let provider =
+        Provider::<Http>::try_from(rpc_url).map_err(|e| anyhow!("Invalid RPC URL: {}", e))?;
+    let to = Address::from_str(contract).map_err(|_| anyhow!("Invalid contract address"))?;
+    let tx = TransactionRequest::new().to(to).data(Bytes::from(data));
+    provider
+        .call(&tx.into(), None)
+        .await
+        .map(|b| b.to_vec())
+        .map_err(|e| anyhow!("eth_call failed: {}", e))
+}
+
+/// App-level shared image digests (each is the on-chain bytes, e.g. b"sha256:...").
+pub async fn get_app_image_hashes(
+    rpc_url: &str,
+    contract: &str,
+    app_id: &str,
+) -> Result<Vec<Vec<u8>>> {
+    let data = calldata("getAppInfo(string)", vec![Token::String(app_id.to_owned())]);
+    let out = call_raw(rpc_url, contract, data).await?;
+    let tuple = ParamType::Tuple(vec![
+        ParamType::Bytes,
+        ParamType::Bytes,
+        ParamType::Array(Box::new(ParamType::Bytes)),
+        ParamType::Address,
+        ParamType::Uint(256),
+    ]);
+    let tokens = decode(&[tuple], &out).map_err(|e| anyhow!("decode getAppInfo: {}", e))?;
+    if let Some(Token::Tuple(fields)) = tokens.into_iter().next() {
+        if let Token::Array(arr) = &fields[2] {
+            return Ok(arr
+                .iter()
+                .filter_map(|t| match t {
+                    Token::Bytes(b) => Some(b.clone()),
+                    _ => None,
+                })
+                .collect());
+        }
+    }
+    Err(anyhow!("unexpected getAppInfo return shape"))
+}
+
+/// Registered node signer addresses for an app (getNodeList).
+pub async fn get_node_list(rpc_url: &str, contract: &str, app_id: &str) -> Result<Vec<Address>> {
+    let data = calldata("getNodeList(string)", vec![Token::String(app_id.to_owned())]);
+    let out = call_raw(rpc_url, contract, data).await?;
+    let tokens = decode(&[ParamType::Array(Box::new(ParamType::Address))], &out)
+        .map_err(|e| anyhow!("decode getNodeList: {}", e))?;
+    if let Some(Token::Array(arr)) = tokens.into_iter().next() {
+        return Ok(arr
+            .into_iter()
+            .filter_map(|t| match t {
+                Token::Address(a) => Some(a),
+                _ => None,
+            })
+            .collect());
+    }
+    Err(anyhow!("unexpected getNodeList return shape"))
+}
+
+/// A node's teeUrl and EFFECTIVE compose/volumes (getNode resolves inherit→default).
+pub async fn get_node(
+    rpc_url: &str,
+    contract: &str,
+    app_id: &str,
+    signer: Address,
+) -> Result<(String, Vec<u8>, Vec<u8>)> {
+    let data = calldata(
+        "getNode(string,address)",
+        vec![Token::String(app_id.to_owned()), Token::Address(signer)],
+    );
+    let out = call_raw(rpc_url, contract, data).await?;
+    // NodeInfo = (string teeUrl, uint256 addedAt, uint256 stakeAmount, bytes composeHash, bytes volumesHash)
+    let tuple = ParamType::Tuple(vec![
+        ParamType::String,
+        ParamType::Uint(256),
+        ParamType::Uint(256),
+        ParamType::Bytes,
+        ParamType::Bytes,
+    ]);
+    let tokens = decode(&[tuple], &out).map_err(|e| anyhow!("decode getNode: {}", e))?;
+    if let Some(Token::Tuple(f)) = tokens.into_iter().next() {
+        let tee_url = match &f[0] {
+            Token::String(s) => s.clone(),
+            _ => String::new(),
+        };
+        let compose = match &f[3] {
+            Token::Bytes(b) => b.clone(),
+            _ => vec![],
+        };
+        let volumes = match &f[4] {
+            Token::Bytes(b) => b.clone(),
+            _ => vec![],
+        };
+        return Ok((tee_url, compose, volumes));
+    }
+    Err(anyhow!("unexpected getNode return shape"))
+}
+
 // ─── Transaction sender ───────────────────────────────────────────────────────
 
 async fn send_tx(

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -1,0 +1,322 @@
+//! End-to-end app verification: on-chain registry → fetch evidence per node →
+//! CoCo-AS quote verification → reconcile evidence against on-chain values.
+//!
+//! This is the Rust core of the verification flow (port of docs/verify_app.py);
+//! `tapp-cli verify-app` is a thin wrapper. Intended to be extracted into the SDK.
+
+use anyhow::{anyhow, Result};
+use base64::Engine;
+use std::collections::{HashMap, HashSet};
+
+use crate::onchain;
+use crate::proto::{tapp_service_client::TappServiceClient, GetEvidenceRequest};
+
+// CoCo Attestation Service gRPC client (proto/attestation.proto).
+pub mod as_proto {
+    tonic::include_proto!("attestation");
+}
+use as_proto::attestation_service_client::AttestationServiceClient;
+use as_proto::{AttestationRequest, IndividualAttestationRequest};
+
+const B64: base64::engine::general_purpose::GeneralPurpose = base64::engine::general_purpose::STANDARD;
+const B64URL: base64::engine::general_purpose::GeneralPurpose =
+    base64::engine::general_purpose::URL_SAFE_NO_PAD;
+
+/// Per-node verification result.
+pub struct NodeVerdict {
+    pub signer: String, // on-chain signer (0x…)
+    pub tee_url: String,
+    pub reachable: bool,
+    pub ear_status: String, // affirming | warning | contraindicated | -
+    pub tcb_status: String,
+    pub advisories: usize,
+    pub signer_ok: bool,  // report_data binds the on-chain signer
+    pub compose_ok: bool, // start_app compose == node effective compose
+    pub volumes_ok: bool,
+    pub image_ok: bool,
+    pub note: String,
+}
+
+impl NodeVerdict {
+    pub fn reconciled(&self) -> bool {
+        self.signer_ok && self.compose_ok && self.volumes_ok && self.image_ok
+    }
+}
+
+pub struct AppVerdict {
+    pub app_id: String,
+    pub nodes: Vec<NodeVerdict>,
+}
+
+struct StartAppMeasure {
+    compose_hash: String,                  // hex
+    volumes_hash: HashMap<String, String>, // file -> hex (empty for legacy string format)
+    image_hash: HashMap<String, String>,   // service -> "sha256:…"
+}
+
+/// report_data (64 bytes) from a TDX quote, header offset resolved by version (v4=48, v5=54).
+fn quote_report_data(quote_b64: &str) -> Result<Vec<u8>> {
+    let q = B64.decode(quote_b64).map_err(|e| anyhow!("quote b64: {}", e))?;
+    if q.len() < 2 {
+        return Err(anyhow!("quote too short"));
+    }
+    let ver = u16::from_le_bytes([q[0], q[1]]);
+    let hdr = match ver {
+        4 => 48,
+        5 => 54,
+        v => return Err(anyhow!("unsupported quote version {}", v)),
+    };
+    let body = q
+        .get(hdr..hdr + 584)
+        .ok_or_else(|| anyhow!("quote body out of range"))?;
+    Ok(body[520..584].to_vec())
+}
+
+fn alg_size(alg: u16) -> usize {
+    match alg {
+        4 => 20,
+        0xb => 32,
+        0xc => 48,
+        0xd => 64,
+        _ => 48,
+    }
+}
+
+/// Parse the cc_eventlog (TCG2) and return the latest successful `start_app` measurement
+/// for `app_id` (from the `tapp.0g.com start_app {…}` EV_EVENT_TAG runtime events).
+fn latest_successful_start(cc_eventlog_b64: &str, app_id: &str) -> Result<Option<StartAppMeasure>> {
+    let log = B64.decode(cc_eventlog_b64).map_err(|e| anyhow!("eventlog b64: {}", e))?;
+    let u32le = |b: &[u8]| u32::from_le_bytes([b[0], b[1], b[2], b[3]]) as usize;
+
+    // skip SpecID event: pcr(4)+type(4)+sha1(20)+size(4)+data
+    let mut o = 8 + 20;
+    if o + 4 > log.len() {
+        return Ok(None);
+    }
+    let ds = u32le(&log[o..o + 4]);
+    o += 4 + ds;
+
+    let mut last: Option<StartAppMeasure> = None;
+    while o + 12 <= log.len() {
+        o += 4; // pcrIndex
+        let et = u32le(&log[o..o + 4]);
+        o += 4;
+        let cnt = u32le(&log[o..o + 4]);
+        o += 4;
+        for _ in 0..cnt {
+            if o + 2 > log.len() {
+                return Ok(last);
+            }
+            let alg = u16::from_le_bytes([log[o], log[o + 1]]);
+            o += 2 + alg_size(alg);
+        }
+        if o + 4 > log.len() {
+            break;
+        }
+        let dl = u32le(&log[o..o + 4]);
+        o += 4;
+        if o + dl > log.len() {
+            break;
+        }
+        let data = &log[o..o + dl];
+        o += dl;
+
+        if et == 0x6 && dl >= 8 {
+            let tsz = u32le(&data[4..8]);
+            if 8 + tsz <= data.len() {
+                if let Ok(text) = std::str::from_utf8(&data[8..8 + tsz]) {
+                    if let Some(payload) = text.strip_prefix("tapp.0g.com start_app ") {
+                        if let Ok(v) = serde_json::from_str::<serde_json::Value>(payload) {
+                            if v["app_id"].as_str() == Some(app_id)
+                                && v["result"].as_str() == Some("success")
+                            {
+                                last = Some(StartAppMeasure {
+                                    compose_hash: v["compose_hash"]
+                                        .as_str()
+                                        .unwrap_or("")
+                                        .to_string(),
+                                    volumes_hash: json_str_map(&v["volumes_hash"]),
+                                    image_hash: json_str_map(&v["image_hash"]),
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Ok(last)
+}
+
+fn json_str_map(v: &serde_json::Value) -> HashMap<String, String> {
+    let mut m = HashMap::new();
+    if let Some(obj) = v.as_object() {
+        for (k, val) in obj {
+            if let Some(s) = val.as_str() {
+                m.insert(k.clone(), s.to_string());
+            }
+        }
+    }
+    m
+}
+
+/// Submit evidence to CoCo-AS (gRPC) and return (ear_status, tcb_status, advisory_count).
+async fn verify_with_as(as_endpoint: &str, raw_evidence: &[u8]) -> Result<(String, String, usize)> {
+    let mut client = AttestationServiceClient::connect(format!("http://{}", as_endpoint))
+        .await
+        .map_err(|e| anyhow!("connect AS {}: {}", as_endpoint, e))?;
+    let req = AttestationRequest {
+        verification_requests: vec![IndividualAttestationRequest {
+            tee: "tdx".to_string(),
+            evidence: B64URL.encode(raw_evidence),
+            runtime_data: None, // no nonce binding for pre-generated, signer-bound evidence
+            init_data: None,
+            runtime_data_hash_algorithm: String::new(),
+        }],
+        policy_ids: vec![],
+    };
+    let token = client
+        .attestation_evaluate(req)
+        .await
+        .map_err(|e| anyhow!("AttestationEvaluate: {}", e))?
+        .into_inner()
+        .attestation_token;
+
+    // EAR token is a JWT; decode the payload (middle segment) — the AS already verified.
+    let seg = token
+        .split('.')
+        .nth(1)
+        .ok_or_else(|| anyhow!("malformed attestation token"))?;
+    let payload = B64URL
+        .decode(seg)
+        .map_err(|e| anyhow!("token payload b64: {}", e))?;
+    let claims: serde_json::Value = serde_json::from_slice(&payload)?;
+    let cpu0 = &claims["submods"]["cpu0"];
+    let ear_status = cpu0["ear.status"].as_str().unwrap_or("unknown").to_string();
+    let tdx = &cpu0["ear.veraison.annotated-evidence"]["tdx"];
+    let tcb = tdx["tcb_status"].as_str().unwrap_or("unknown").to_string();
+    let adv = tdx["advisory_ids"].as_array().map(|a| a.len()).unwrap_or(0);
+    Ok((ear_status, tcb, adv))
+}
+
+async fn fetch_evidence(tee_url: &str, app_id: &str) -> Result<Vec<u8>> {
+    let mut client = TappServiceClient::connect(tee_url.to_string())
+        .await
+        .map_err(|e| anyhow!("connect {}: {}", tee_url, e))?;
+    let resp = client
+        .get_evidence(tonic::Request::new(GetEvidenceRequest {
+            app_id: app_id.to_owned(),
+        }))
+        .await
+        .map_err(|e| anyhow!("{}", e))?
+        .into_inner();
+    Ok(resp.evidence)
+}
+
+/// Verify every node of `app_id`: read chain, fetch evidence from each node's teeUrl,
+/// verify the quote via CoCo-AS, and reconcile evidence against on-chain values.
+pub async fn verify_app(
+    rpc_url: &str,
+    contract: &str,
+    app_id: &str,
+    as_endpoint: &str,
+) -> Result<AppVerdict> {
+    let signers = onchain::get_node_list(rpc_url, contract, app_id).await?;
+    if signers.is_empty() {
+        return Err(anyhow!("app '{}' has no registered nodes on-chain", app_id));
+    }
+    let app_image_set: HashSet<Vec<u8>> = onchain::get_app_image_hashes(rpc_url, contract, app_id)
+        .await?
+        .into_iter()
+        .collect();
+
+    let mut nodes = Vec::new();
+    for signer in signers {
+        let mut v = NodeVerdict {
+            signer: format!("0x{}", hex::encode(signer.as_bytes())),
+            tee_url: String::new(),
+            reachable: false,
+            ear_status: "-".to_string(),
+            tcb_status: "-".to_string(),
+            advisories: 0,
+            signer_ok: false,
+            compose_ok: false,
+            volumes_ok: false,
+            image_ok: false,
+            note: String::new(),
+        };
+
+        // ① chain: node teeUrl + effective compose/volumes
+        let (tee_url, eff_compose, eff_volumes) =
+            match onchain::get_node(rpc_url, contract, app_id, signer).await {
+                Ok(x) => x,
+                Err(e) => {
+                    v.note = format!("getNode failed: {}", e);
+                    nodes.push(v);
+                    continue;
+                }
+            };
+        v.tee_url = tee_url.clone();
+
+        // ② fetch evidence
+        let raw = match fetch_evidence(&tee_url, app_id).await {
+            Ok(b) => b,
+            Err(e) => {
+                v.note = format!("get-evidence failed: {}", e);
+                nodes.push(v);
+                continue;
+            }
+        };
+        v.reachable = true;
+        let j: serde_json::Value = match serde_json::from_slice(&raw) {
+            Ok(x) => x,
+            Err(e) => {
+                v.note = format!("evidence not JSON: {}", e);
+                nodes.push(v);
+                continue;
+            }
+        };
+        let quote_b64 = j["quote"].as_str().unwrap_or("");
+        let cc_b64 = j["cc_eventlog"].as_str().unwrap_or("");
+
+        // ④a signer binding: on-chain signer (20 bytes) present in report_data
+        if let Ok(rd) = quote_report_data(quote_b64) {
+            let needle = signer.as_bytes();
+            v.signer_ok = rd.windows(needle.len()).any(|w| w == needle);
+        } else {
+            v.note = "quote parse failed; ".to_string();
+        }
+
+        // ③ AS quote verification
+        match verify_with_as(as_endpoint, &raw).await {
+            Ok((s, t, a)) => {
+                v.ear_status = s;
+                v.tcb_status = t;
+                v.advisories = a;
+            }
+            Err(e) => v.note = format!("{}AS: {}", v.note, e),
+        }
+
+        // ④b reconcile compose/volumes/image vs chain
+        match latest_successful_start(cc_b64, app_id) {
+            Ok(Some(m)) => {
+                if let Ok(c) = hex::decode(&m.compose_hash) {
+                    v.compose_ok = c == eff_compose;
+                }
+                v.volumes_ok = onchain::combine_map_hashes(&m.volumes_hash) == eff_volumes;
+                let ev_imgs: HashSet<Vec<u8>> =
+                    m.image_hash.values().map(|s| s.as_bytes().to_vec()).collect();
+                v.image_ok = ev_imgs == app_image_set;
+            }
+            Ok(None) => v.note = format!("{}no successful start_app in eventlog", v.note),
+            Err(e) => v.note = format!("{}eventlog parse: {}", v.note, e),
+        }
+
+        nodes.push(v);
+    }
+
+    Ok(AppVerdict {
+        app_id: app_id.to_string(),
+        nodes,
+    })
+}

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -213,6 +213,63 @@ async fn fetch_evidence(tee_url: &str, app_id: &str) -> Result<Vec<u8>> {
     Ok(resp.evidence)
 }
 
+/// Direct (no-chain) verification of a single server: fetch evidence, verify the quote
+/// via CoCo-AS, and report what the node attests. No on-chain reconciliation — used when
+/// the app is not (yet) registered on-chain, or to check one node directly.
+pub struct DirectVerdict {
+    pub server: String,
+    pub signer: String, // from quote report_data (0x…), as attested (not reconciled)
+    pub ear_status: String,
+    pub tcb_status: String,
+    pub advisories: usize,
+    pub compose_hash: String, // from latest successful start_app, if any
+    pub images: Vec<String>,
+    pub note: String,
+}
+
+pub async fn verify_node_direct(
+    server: &str,
+    app_id: &str,
+    as_endpoint: &str,
+) -> Result<DirectVerdict> {
+    let mut v = DirectVerdict {
+        server: server.to_string(),
+        signer: String::new(),
+        ear_status: "-".to_string(),
+        tcb_status: "-".to_string(),
+        advisories: 0,
+        compose_hash: String::new(),
+        images: Vec::new(),
+        note: String::new(),
+    };
+
+    let raw = fetch_evidence(server, app_id).await?;
+    let j: serde_json::Value = serde_json::from_slice(&raw)?;
+    let quote_b64 = j["quote"].as_str().unwrap_or("");
+    let cc_b64 = j["cc_eventlog"].as_str().unwrap_or("");
+
+    if let Ok(rd) = quote_report_data(quote_b64) {
+        v.signer = format!("0x{}", hex::encode(&rd[..20]));
+    } else {
+        v.note = "quote parse failed; ".to_string();
+    }
+
+    match verify_with_as(as_endpoint, &raw).await {
+        Ok((s, t, a)) => {
+            v.ear_status = s;
+            v.tcb_status = t;
+            v.advisories = a;
+        }
+        Err(e) => v.note = format!("{}AS: {}", v.note, e),
+    }
+
+    if let Ok(Some(m)) = latest_successful_start(cc_b64, app_id) {
+        v.compose_hash = m.compose_hash;
+        v.images = m.image_hash.into_values().collect();
+    }
+    Ok(v)
+}
+
 /// Verify every node of `app_id`: read chain, fetch evidence from each node's teeUrl,
 /// verify the quote via CoCo-AS, and reconcile evidence against on-chain values.
 pub async fn verify_app(


### PR DESCRIPTION
## What
`tapp-cli verify-app --app-id X` takes **only an app_id** and runs the full trust check:
1. read on-chain `TappRegistry`: node list, each node's `teeUrl` + **effective** compose/volumes (getNode resolves inherit→default), app-level image hashes;
2. fetch evidence from each node's `teeUrl`;
3. verify the TDX quote via **CoCo-AS** (gRPC `:50004`) → EAR token (`ear.status` / `tcb_status` / advisories);
4. **reconcile** evidence vs chain: report_data signer, compose, volumes, image.

This is the Rust port of `docs/verify_app.py` and the intended **core of the SDK (#9)**; it supersedes the standalone script (and the planned `verify_app.py` adaptation follow-up).

## Pieces
- `proto/attestation.proto` + `build.rs`: CoCo-AS gRPC client.
- `onchain.rs`: `get_node_list`, `get_node` (effective compose/volumes), `get_app_image_hashes`.
- `verify.rs`: version-aware quote parsing (report_data→signer; v4=48/v5=54 header), cc_eventlog parse (latest successful `start_app`), AS `AttestationEvaluate` + EAR parse, reconciliation.
- `cli.rs`: `verify-app` (default AS endpoint `47.237.201.184:50004`, overridable).

## E2E (testnet test instance `0x2Ce8…`, app `0g-kms`, 2 nodes)
- node1 — `signer✓ compose✓ volumes✓ image✓` → reconcile **PASS**.
- node2 — `compose✓ volumes✓ image✓` but `signer✗` → reconcile **FAIL**: its current report_data signer drifted from the on-chain registration (needs `update-node-onchain`). Correctly caught.
- Both quotes: `tcb_status=OutOfDate` → `contraindicated` (expected for these hosts).

## Notes
- Depends on per-node-compose (#8, merged) — uses getNode's resolved effective values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)