### PR TITLE
docs: document list-apps & verify-app, fix stale -s note

### DIFF
--- a/.claude/skills/0g-tapp-cli/SKILL.md
+++ b/.claude/skills/0g-tapp-cli/SKILL.md
@@ -14,9 +14,9 @@ Deploy and manage containerized applications on 0G Tapp TEE servers using `tapp-
 
 - **tapp-cli binary**: `/usr/local/bin/tapp-cli`
 - **Server**: `-s <url>` (e.g. `http://<host>:50051`). There are MANY tapp servers; always pass `-s` explicitly.
-- **Auth**: private key via `-k` flag or `TAPP_PRIVATE_KEY` env var. Read-only commands (`get-tapp-info`, `get-service-status`, `get-app-info`, `get-app-key`, `get-evidence`) work without `-k`; owner-only commands require it.
+- **Auth**: private key via `-k` flag or `TAPP_PRIVATE_KEY` env var. Read-only commands (`get-tapp-info`, `get-service-status`, `get-app-info`, `get-app-key`, `get-evidence`, `list-apps`, `verify-app` direct mode) work without `-k`; owner-only commands require it.
 - **TappRegistry (testnet)**: proxy `0x95a0BF4148b30F6F8D86870534c51df46Da5511c`, RPC `https://evmrpc-testnet.0g.ai`, chainId `16602`. See `contract/CONTRACTS.md`.
-- **⚠️ Short flag `-s` conflict**: the global `-s` / `--server` flag is shadowed by local `-s` in `register-onchain` (`--stake-wei`), `get-app-logs` (`--service`), and `verify-signature` (`--signature`). Always use `--server` (full name) with these subcommands.
+- **Short flags**: `-s` = `--server` and `-k` = `--private-key` (both global). The earlier `-s` collision is **fixed** — the formerly-clashing subcommand flags (`--stake-wei`, `--service`, `--service-name`, `--signature`, `--chain-id`) are long-only now, so `-s` always means `--server`.
 
 ## Keys & servers — read this first
 
@@ -40,8 +40,11 @@ tapp-cli -s <server> -k 0x<key> stop-service  --app-id <id> --service-name <svc>
 tapp-cli -s <server> -k 0x<key> start-service --app-id <id> --service-name <svc>
 tapp-cli -s <server> -k 0x<key> get-app-container-status --app-id <id>
 tapp-cli -s <server> -k 0x<key> get-app-info --app-id <id>        # compose/volume/image hashes the server holds
-tapp-cli -s <server> -k 0x<key> get-app-logs --app-id <id> --service <name> -n 100  # note: use --server, not -s (see above)
+tapp-cli -s <server> list-apps                                   # list all apps on this server (no key needed)
+tapp-cli -s <server> -k 0x<key> get-app-logs --app-id <id> --service <name> -n 100  # app's docker compose logs
 tapp-cli -s <server> -k 0x<key> get-app-key --app-id <id>         # TEE-derived app signing key (ethereum); --key-type / --x25519 for other types
+tapp-cli -s <server> verify-app --app-id <id>                     # direct: AS-verify this node's evidence+quote, show attested values (no chain)
+tapp-cli verify-app --app-id <id> --rpc-url <rpc> --contract 0x<reg>  # chain: verify all nodes + reconcile vs on-chain (--as-endpoint default 47.237.201.184:50004)
 tapp-cli -s <server> -k 0x<key> get-tapp-info                     # server version + Owner Address (no key needed)
 tapp-cli -s <server> -k 0x<key> prune-images [--all]              # delete UNUSED images (--all removes all unused, not just dangling)
 tapp-cli -s <server> -k 0x<key> get-service-logs -f <file> [-n 100] # tapp-server's own logs (-n limits lines; no -f lists files)

--- a/README.md
+++ b/README.md
@@ -289,6 +289,32 @@ tapp-cli -s http://<any-tapp>:50051 -k 0x<deployer-key> withdraw \
   --contract 0x<TappRegistry>
 ```
 
+### Verifying an App
+
+`tapp-cli verify-app` checks that what a node actually runs matches what is registered on-chain.
+
+**Chain mode** (pass `--contract` + `--rpc-url`): reads the registry, fetches evidence from every node's on-chain `teeUrl`, verifies each TDX quote via the CoCo Attestation Service, and reconciles the evidence (signer, compose, volumes, image) against the chain.
+
+```bash
+tapp-cli verify-app \
+  --app-id my-app \
+  --rpc-url https://evmrpc-testnet.0g.ai \
+  --contract 0x<TappRegistry>
+  # --as-endpoint host:port   # CoCo-AS gRPC endpoint, default 47.237.201.184:50004
+```
+
+**Direct mode** (omit `--contract`, pass `-s <server>`): verifies a single node's evidence + quote and shows what it attests, without on-chain reconciliation — useful for apps not yet registered.
+
+```bash
+tapp-cli -s http://<tapp>:50051 verify-app --app-id my-app
+```
+
+List the apps a server is currently running (read-only, no key needed):
+
+```bash
+tapp-cli -s http://<tapp>:50051 list-apps
+```
+
 ### Managing Ack Invalidators
 
 User acknowledgements (acks) on TappRegistry are tied to an app's `ackVersion`, which bumps automatically on `updateApp` and node changes. When a sibling contract (e.g. a pricing or policy contract) needs to invalidate existing user acks without changing the app's code identity, the app owner can authorize that contract as an **invalidator**. Authorized invalidators may call `invalidateAcks(appId)` to bump the version. Both commands are app-owner-only and idempotent (no-op if the state already matches).

--- a/docs/EVIDENCE_AND_AS_VERIFICATION.md
+++ b/docs/EVIDENCE_AND_AS_VERIFICATION.md
@@ -1,5 +1,9 @@
 # 按 App ID 验证 tapp 节点（链上 → 取证 → 验签 → 对账）
 
+> **现在已内置到 CLI**：直接用 `tapp-cli verify-app --app-id <X> --rpc-url <RPC> --contract <Registry>`；
+> 未注册上链时用直连模式 `tapp-cli -s <server> verify-app --app-id <X>`。本文档描述它内部做的事 +
+> 等价的手搓 `cast`/`grpcurl` 流程（`docs/verify_app.py` 是同逻辑的脚本参考；CLI 实现见 `src/verify.rs`）。
+
 **验证器的唯一输入是 `app_id`。** 其余全自动：从链上读该 app 的注册信息和节点列表 →
 顺着每个节点链上记录的 `teeUrl` 取 evidence → 验 quote 签名/TCB → 把 evidence 里的度量与身份跟链上逐项对账。
 


### PR DESCRIPTION
Brings docs in line with recently-merged CLI features (#10 list-apps, #11 -s fix, #12 verify-app).

- **README**: new "Verifying an App" section — `verify-app` chain mode (--contract + --rpc-url, discover + reconcile) and direct mode (-s <server>, no chain); plus `list-apps`.
- **SKILL.md**: add `list-apps` + `verify-app` to the command list; the `-s` conflict warning is now stale (the clashing shorts were removed in #11) → noted as fixed (`-s` always = `--server`); dropped the get-app-logs `--service` caveat.
- **docs/EVIDENCE_AND_AS_VERIFICATION.md**: point to `tapp-cli verify-app` as the built-in way; the doc + `verify_app.py` remain the underlying reference (CLI impl in `src/verify.rs`).

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)