### PR TITLE
fix(ci): build whole workspace so tapp-cli binary is produced

### DIFF
--- a/reproducible_build/Dockerfile
+++ b/reproducible_build/Dockerfile
@@ -71,11 +71,13 @@ WORKDIR /build
 # Copy project files
 COPY . .
 
-# Build both binaries in release mode
+# Build both binaries in release mode. --workspace is required: the root package is
+# tapp-server, and tapp-cli is a separate workspace member (not a dependency of the
+# root), so a plain `cargo build` would not produce target/release/tapp-cli.
 # This produces:
 # - /build/target/release/tapp-server
 # - /build/target/release/tapp-cli
-RUN cargo build --release
+RUN cargo build --release --workspace
 
 # Copy build artifacts to output directory
 RUN mkdir -p /output && \


### PR DESCRIPTION
## Problem
The v0.1.0 release workflow ("Build and Sign Binaries") failed:
```
cp: cannot stat '/build/target/release/tapp-cli': No such file or directory
```
After the workspace refactor (#17), the root package is `tapp-server` and `tapp-cli` is a separate workspace member (not a dependency of root). The Dockerfile's `cargo build --release` therefore only builds `tapp-server`, so `target/release/tapp-cli` is never produced and the `cp` step fails.

## Fix
`reproducible_build/Dockerfile`: `cargo build --release` → `cargo build --release --workspace`, so all members (incl. `tapp-cli`) are built.

## Verification
Local `cargo build --release --workspace` produces **both** `target/release/tapp-server` and `target/release/tapp-cli`.

After merge: re-point/re-cut the `v0.1.0` tag (or cut `v0.1.1`) to trigger the release workflow on a commit that includes this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)