### PR TITLE
feat(cli): verify-app --policy-ids to enforce a boot-chain policy

### DIFF
--- a/.claude/skills/0g-tapp-cli/SKILL.md
+++ b/.claude/skills/0g-tapp-cli/SKILL.md
@@ -43,13 +43,20 @@ tapp-cli -s <server> -k 0x<key> get-app-info --app-id <id>        # compose/volu
 tapp-cli -s <server> list-apps                                   # list all apps on this server (no key needed)
 tapp-cli -s <server> -k 0x<key> get-app-logs --app-id <id> --service <name> -n 100  # app's docker compose logs
 tapp-cli -s <server> -k 0x<key> get-app-key --app-id <id>         # TEE-derived app signing key (ethereum); --key-type / --x25519 for other types
-tapp-cli -s <server> verify-app --app-id <id>                     # direct: AS-verify this node's evidence+quote, show attested values (no chain)
-tapp-cli verify-app --app-id <id> --rpc-url <rpc> --contract 0x<reg>  # chain: verify all nodes + reconcile vs on-chain (--as-endpoint default 47.237.201.184:50004)
+tapp-cli -s <server> verify-app --app-id <id> [--policy-ids <id>]                    # direct: AS-verify this node's evidence+quote, show attested values (no chain)
+tapp-cli verify-app --app-id <id> --rpc-url <rpc> --contract 0x<reg> [--policy-ids <id>]  # chain: verify all nodes + reconcile vs on-chain
 tapp-cli -s <server> -k 0x<key> get-tapp-info                     # server version + Owner Address (no key needed)
 tapp-cli -s <server> -k 0x<key> prune-images [--all]              # delete UNUSED images (--all removes all unused, not just dangling)
 tapp-cli -s <server> -k 0x<key> get-service-logs -f <file> [-n 100] # tapp-server's own logs (-n limits lines; no -f lists files)
 tapp-cli -s <server> -k 0x<key> docker-logout                    # logout from Docker registry on this server
 ```
+
+### verify-app: boot-chain check (`--policy-ids`)
+- **`--policy-ids <id>` is what triggers the boot-chain check** (shim/grub/kernel/initrd/kernel_cmdline vs an image's reference values). **Without it**, the AS uses its default policy and **no `boot-chain` line is printed** — only `ear.status`/`tcb_status`.
+- Output line: `boot-chain : ✓ (executables=3, matches policy reference)` = matched; `✗ (executables=33, ...)` = did not match; `?` = policy set no executables claim. (`executables` is the AR4SI claim: **3** = approved boot chain, **33** = unrecognized.)
+- **`--as-endpoint <host:port>`** picks the Attestation Service (default `47.237.201.184:50004`, the shared AS). Point it at a self-hosted local AS (e.g. `127.0.0.1:50004`, see `0g-tapp-verifier`) to use RVPS-backed reference values.
+- **Policy ids** must be registered on that AS first (the AS appends `_cpu`, so register `<id>_cpu`). Known ids: `0g-tapp` (sample/target values) and image-specific ones like `0g-tapp-gcp-dev`. Use the id whose reference values match the node's image.
+- Note: `ear.status=affirming` also needs platform TCB `UpToDate`; `executables=3` alone (boot chain matched) is the boot-chain conclusion independent of TCB.
 
 ### Server health & whitelist
 ```bash

--- a/tapp-cli/Cargo.toml
+++ b/tapp-cli/Cargo.toml
@@ -35,3 +35,6 @@ ethers = { version = "2.0", default-features = false, features = ["legacy", "rus
 
 # Error handling
 thiserror = "1.0"
+
+[dev-dependencies]
+tempfile = "3.23.0"

--- a/tapp-cli/src/main.rs
+++ b/tapp-cli/src/main.rs
@@ -1008,6 +1008,24 @@ async fn get_app_info(server: &str, app_id: String) -> Result<(), Box<dyn std::e
     Ok(())
 }
 
+/// Render the boot-chain result line from the AS `executables` claim.
+/// Returns None when no policy was selected (`show=false`) — the AS default policy's
+/// executables claim is not our boot-chain check, so we don't show it. The caller adds
+/// section-appropriate indentation.
+fn boot_chain_line(executables: Option<i64>, show: bool) -> Option<String> {
+    use tapp_common::verify::EXECUTABLES_MATCHED;
+    if !show {
+        return None;
+    }
+    Some(match executables {
+        Some(n) if n == EXECUTABLES_MATCHED => {
+            format!("boot-chain : ✓ (executables={}, matches policy reference)", n)
+        }
+        Some(n) => format!("boot-chain : ✗ (executables={}, no policy match)", n),
+        None => "boot-chain : ? (policy set no executables claim)".to_string(),
+    })
+}
+
 async fn verify_app_cmd(
     server: &str,
     app_id: &str,
@@ -1019,16 +1037,6 @@ async fn verify_app_cmd(
     // boot-chain line is meaningful only when WE selected a policy (otherwise the AS
     // default policy's executables claim is not our boot-chain check).
     let show_boot = !policy_ids.is_empty();
-    let boot = |ex: Option<i64>| -> String {
-        if !show_boot {
-            return String::new();
-        }
-        match ex {
-            Some(3) => "boot-chain : ✓ (executables=3, matches policy reference)".to_string(),
-            Some(n) => format!("boot-chain : ✗ (executables={}, no policy match)", n),
-            None => "boot-chain : ? (policy set no executables claim)".to_string(),
-        }
-    };
     // Direct mode: no --contract → verify the single --server node without chain reconciliation.
     if contract.is_none() {
         let d = tapp_common::verify::verify_node_direct(server, app_id, as_endpoint, policy_ids).await?;
@@ -1037,8 +1045,9 @@ async fn verify_app_cmd(
         println!("  server      : {}", d.server);
         println!("  signer      : {}  (attested in report_data)", d.signer);
         println!("  AS          : ear.status={} tcb_status={} advisories={}", d.ear_status, d.tcb_status, d.advisories);
-        let b = boot(d.boot_executables);
-        if !b.is_empty() { println!("{}", b.trim_start()); }
+        if let Some(l) = boot_chain_line(d.boot_executables, show_boot) {
+            println!("  {}", l);
+        }
         if !d.compose_hash.is_empty() {
             println!("  compose     : {}", d.compose_hash);
         }
@@ -1080,8 +1089,9 @@ async fn verify_app_cmd(
             "    reconcile  : signer{} compose{} volumes{} image{}",
             yn(n.signer_ok), yn(n.compose_ok), yn(n.volumes_ok), yn(n.image_ok)
         );
-        let b = boot(n.boot_executables);
-        if !b.is_empty() { println!("  {}", b); }
+        if let Some(l) = boot_chain_line(n.boot_executables, show_boot) {
+            println!("    {}", l);
+        }
         if !n.note.is_empty() {
             println!("    note       : {}", n.note);
         }
@@ -2195,6 +2205,34 @@ mod tests {
     use super::*;
     use std::fs;
     use tempfile::TempDir;
+
+    #[test]
+    fn boot_chain_line_hidden_when_no_policy() {
+        // show=false (no --policy-ids) → no line regardless of executables
+        assert_eq!(boot_chain_line(Some(3), false), None);
+        assert_eq!(boot_chain_line(Some(33), false), None);
+        assert_eq!(boot_chain_line(None, false), None);
+    }
+
+    #[test]
+    fn boot_chain_line_match() {
+        let l = boot_chain_line(Some(3), true).unwrap();
+        assert!(l.starts_with("boot-chain : ✓"), "got: {}", l);
+        assert!(l.contains("executables=3"));
+    }
+
+    #[test]
+    fn boot_chain_line_no_match() {
+        let l = boot_chain_line(Some(33), true).unwrap();
+        assert!(l.starts_with("boot-chain : ✗"), "got: {}", l);
+        assert!(l.contains("executables=33"));
+    }
+
+    #[test]
+    fn boot_chain_line_no_claim() {
+        let l = boot_chain_line(None, true).unwrap();
+        assert!(l.starts_with("boot-chain : ?"), "got: {}", l);
+    }
 
     fn write_file(dir: &std::path::Path, name: &str, content: &str) {
         let path = dir.join(name);

--- a/tapp-cli/src/main.rs
+++ b/tapp-cli/src/main.rs
@@ -81,6 +81,10 @@ enum Commands {
         /// CoCo Attestation Service gRPC endpoint (host:port)
         #[arg(long, default_value = "47.237.201.184:50004")]
         as_endpoint: String,
+        /// AS policy id to enforce (enables boot-chain check). Empty = AS default
+        /// policy (no boot-chain check). E.g. --policy-ids 0g-tapp
+        #[arg(long)]
+        policy_ids: Vec<String>,
     },
     /// List all apps currently on the server
     ListApps,
@@ -490,8 +494,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Commands::GetAppInfo { app_id } => {
             get_app_info(&cli.server, app_id).await?;
         }
-        Commands::VerifyApp { app_id, rpc_url, contract, as_endpoint } => {
-            verify_app_cmd(&cli.server, &app_id, rpc_url, contract, &as_endpoint).await?;
+        Commands::VerifyApp { app_id, rpc_url, contract, as_endpoint, policy_ids } => {
+            verify_app_cmd(&cli.server, &app_id, rpc_url, contract, &as_endpoint, &policy_ids).await?;
         }
         Commands::ListApps => {
             list_apps(&cli.server).await?;
@@ -1010,15 +1014,31 @@ async fn verify_app_cmd(
     rpc_url: Option<String>,
     contract: Option<String>,
     as_endpoint: &str,
+    policy_ids: &[String],
 ) -> Result<(), Box<dyn std::error::Error>> {
+    // boot-chain line is meaningful only when WE selected a policy (otherwise the AS
+    // default policy's executables claim is not our boot-chain check).
+    let show_boot = !policy_ids.is_empty();
+    let boot = |ex: Option<i64>| -> String {
+        if !show_boot {
+            return String::new();
+        }
+        match ex {
+            Some(3) => "boot-chain : ✓ (executables=3, matches policy reference)".to_string(),
+            Some(n) => format!("boot-chain : ✗ (executables={}, no policy match)", n),
+            None => "boot-chain : ? (policy set no executables claim)".to_string(),
+        }
+    };
     // Direct mode: no --contract → verify the single --server node without chain reconciliation.
     if contract.is_none() {
-        let d = tapp_common::verify::verify_node_direct(server, app_id, as_endpoint).await?;
+        let d = tapp_common::verify::verify_node_direct(server, app_id, as_endpoint, policy_ids).await?;
         let quote_ok = d.ear_status == "affirming";
         println!("Verifying app: {}  (direct mode — no on-chain reconciliation)", app_id);
         println!("  server      : {}", d.server);
         println!("  signer      : {}  (attested in report_data)", d.signer);
         println!("  AS          : ear.status={} tcb_status={} advisories={}", d.ear_status, d.tcb_status, d.advisories);
+        let b = boot(d.boot_executables);
+        if !b.is_empty() { println!("{}", b.trim_start()); }
         if !d.compose_hash.is_empty() {
             println!("  compose     : {}", d.compose_hash);
         }
@@ -1036,7 +1056,7 @@ async fn verify_app_cmd(
     // Chain mode.
     let rpc_url = rpc_url.ok_or("chain mode requires --rpc-url (or omit --contract for direct mode)")?;
     let contract = contract.unwrap();
-    let verdict = tapp_common::verify::verify_app(&rpc_url, &contract, app_id, as_endpoint).await?;
+    let verdict = tapp_common::verify::verify_app(&rpc_url, &contract, app_id, as_endpoint, policy_ids).await?;
 
     let yn = |b: bool| if b { "✓" } else { "✗" };
     println!("Verifying app: {}  ({} node(s))", verdict.app_id, verdict.nodes.len());
@@ -1060,6 +1080,8 @@ async fn verify_app_cmd(
             "    reconcile  : signer{} compose{} volumes{} image{}",
             yn(n.signer_ok), yn(n.compose_ok), yn(n.volumes_ok), yn(n.image_ok)
         );
+        let b = boot(n.boot_executables);
+        if !b.is_empty() { println!("  {}", b); }
         if !n.note.is_empty() {
             println!("    note       : {}", n.note);
         }

--- a/tapp-common/src/verify.rs
+++ b/tapp-common/src/verify.rs
@@ -30,6 +30,7 @@ pub struct NodeVerdict {
     pub compose_ok: bool, // start_app compose == node effective compose
     pub volumes_ok: bool,
     pub image_ok: bool,
+    pub boot_executables: Option<i64>, // AR4SI executables claim (3 = boot chain matched policy)
     pub note: String,
 }
 
@@ -156,8 +157,18 @@ fn json_str_map(v: &serde_json::Value) -> HashMap<String, String> {
     m
 }
 
-/// Submit evidence to CoCo-AS (gRPC) and return (ear_status, tcb_status, advisory_count).
-async fn verify_with_as(as_endpoint: &str, raw_evidence: &[u8]) -> Result<(String, String, usize)> {
+/// AS verification result: (ear_status, tcb_status, advisory_count, executables_claim).
+/// `executables` is the AR4SI executables trust claim (3 = boot chain matched the policy
+/// reference values); None if the policy didn't set it / no policy was applied.
+type AsVerdict = (String, String, usize, Option<i64>);
+
+/// Submit evidence to CoCo-AS (gRPC). `policy_ids` selects the policy to enforce; pass an
+/// empty slice to use the AS default policy (which does NOT check our boot chain).
+async fn verify_with_as(
+    as_endpoint: &str,
+    raw_evidence: &[u8],
+    policy_ids: &[String],
+) -> Result<AsVerdict> {
     let mut client = AttestationServiceClient::connect(format!("http://{}", as_endpoint))
         .await
         .map_err(|e| anyhow!("connect AS {}: {}", as_endpoint, e))?;
@@ -169,7 +180,7 @@ async fn verify_with_as(as_endpoint: &str, raw_evidence: &[u8]) -> Result<(Strin
             init_data: None,
             runtime_data_hash_algorithm: String::new(),
         }],
-        policy_ids: vec![],
+        policy_ids: policy_ids.to_vec(),
     };
     let token = client
         .attestation_evaluate(req)
@@ -189,10 +200,11 @@ async fn verify_with_as(as_endpoint: &str, raw_evidence: &[u8]) -> Result<(Strin
     let claims: serde_json::Value = serde_json::from_slice(&payload)?;
     let cpu0 = &claims["submods"]["cpu0"];
     let ear_status = cpu0["ear.status"].as_str().unwrap_or("unknown").to_string();
+    let executables = cpu0["ear.trustworthiness-vector"]["executables"].as_i64();
     let tdx = &cpu0["ear.veraison.annotated-evidence"]["tdx"];
     let tcb = tdx["tcb_status"].as_str().unwrap_or("unknown").to_string();
     let adv = tdx["advisory_ids"].as_array().map(|a| a.len()).unwrap_or(0);
-    Ok((ear_status, tcb, adv))
+    Ok((ear_status, tcb, adv, executables))
 }
 
 async fn fetch_evidence(tee_url: &str, app_id: &str) -> Result<Vec<u8>> {
@@ -218,6 +230,7 @@ pub struct DirectVerdict {
     pub ear_status: String,
     pub tcb_status: String,
     pub advisories: usize,
+    pub boot_executables: Option<i64>, // AR4SI executables claim (3 = boot chain matched policy)
     pub compose_hash: String, // from latest successful start_app, if any
     pub images: Vec<String>,
     pub note: String,
@@ -227,6 +240,7 @@ pub async fn verify_node_direct(
     server: &str,
     app_id: &str,
     as_endpoint: &str,
+    policy_ids: &[String],
 ) -> Result<DirectVerdict> {
     let mut v = DirectVerdict {
         server: server.to_string(),
@@ -234,6 +248,7 @@ pub async fn verify_node_direct(
         ear_status: "-".to_string(),
         tcb_status: "-".to_string(),
         advisories: 0,
+        boot_executables: None,
         compose_hash: String::new(),
         images: Vec::new(),
         note: String::new(),
@@ -250,11 +265,12 @@ pub async fn verify_node_direct(
         v.note = "quote parse failed; ".to_string();
     }
 
-    match verify_with_as(as_endpoint, &raw).await {
-        Ok((s, t, a)) => {
+    match verify_with_as(as_endpoint, &raw, policy_ids).await {
+        Ok((s, t, a, ex)) => {
             v.ear_status = s;
             v.tcb_status = t;
             v.advisories = a;
+            v.boot_executables = ex;
         }
         Err(e) => v.note = format!("{}AS: {}", v.note, e),
     }
@@ -273,6 +289,7 @@ pub async fn verify_app(
     contract: &str,
     app_id: &str,
     as_endpoint: &str,
+    policy_ids: &[String],
 ) -> Result<AppVerdict> {
     let signers = onchain::get_node_list(rpc_url, contract, app_id).await?;
     if signers.is_empty() {
@@ -296,6 +313,7 @@ pub async fn verify_app(
             compose_ok: false,
             volumes_ok: false,
             image_ok: false,
+            boot_executables: None,
             note: String::new(),
         };
 
@@ -341,11 +359,12 @@ pub async fn verify_app(
         }
 
         // ③ AS quote verification
-        match verify_with_as(as_endpoint, &raw).await {
-            Ok((s, t, a)) => {
+        match verify_with_as(as_endpoint, &raw, policy_ids).await {
+            Ok((s, t, a, ex)) => {
                 v.ear_status = s;
                 v.tcb_status = t;
                 v.advisories = a;
+                v.boot_executables = ex;
             }
             Err(e) => v.note = format!("{}AS: {}", v.note, e),
         }

--- a/tapp-common/src/verify.rs
+++ b/tapp-common/src/verify.rs
@@ -157,10 +157,19 @@ fn json_str_map(v: &serde_json::Value) -> HashMap<String, String> {
     m
 }
 
-/// AS verification result: (ear_status, tcb_status, advisory_count, executables_claim).
-/// `executables` is the AR4SI executables trust claim (3 = boot chain matched the policy
-/// reference values); None if the policy didn't set it / no policy was applied.
-type AsVerdict = (String, String, usize, Option<i64>);
+/// CoCo-AS AR4SI `executables` trust-claim value meaning the boot chain matched the
+/// policy's reference values ("only a recognized set of approved executables was loaded").
+pub const EXECUTABLES_MATCHED: i64 = 3;
+
+/// Result of submitting evidence to the AS.
+pub struct AsVerdict {
+    pub ear_status: String,
+    pub tcb_status: String,
+    pub advisories: usize,
+    /// AR4SI executables trust claim (== EXECUTABLES_MATCHED when the boot chain matched
+    /// the policy reference values); None if the policy set no executables / no policy applied.
+    pub executables: Option<i64>,
+}
 
 /// Submit evidence to CoCo-AS (gRPC). `policy_ids` selects the policy to enforce; pass an
 /// empty slice to use the AS default policy (which does NOT check our boot chain).
@@ -204,7 +213,7 @@ async fn verify_with_as(
     let tdx = &cpu0["ear.veraison.annotated-evidence"]["tdx"];
     let tcb = tdx["tcb_status"].as_str().unwrap_or("unknown").to_string();
     let adv = tdx["advisory_ids"].as_array().map(|a| a.len()).unwrap_or(0);
-    Ok((ear_status, tcb, adv, executables))
+    Ok(AsVerdict { ear_status, tcb_status: tcb, advisories: adv, executables })
 }
 
 async fn fetch_evidence(tee_url: &str, app_id: &str) -> Result<Vec<u8>> {
@@ -266,11 +275,11 @@ pub async fn verify_node_direct(
     }
 
     match verify_with_as(as_endpoint, &raw, policy_ids).await {
-        Ok((s, t, a, ex)) => {
-            v.ear_status = s;
-            v.tcb_status = t;
-            v.advisories = a;
-            v.boot_executables = ex;
+        Ok(av) => {
+            v.ear_status = av.ear_status;
+            v.tcb_status = av.tcb_status;
+            v.advisories = av.advisories;
+            v.boot_executables = av.executables;
         }
         Err(e) => v.note = format!("{}AS: {}", v.note, e),
     }
@@ -360,11 +369,11 @@ pub async fn verify_app(
 
         // ③ AS quote verification
         match verify_with_as(as_endpoint, &raw, policy_ids).await {
-            Ok((s, t, a, ex)) => {
-                v.ear_status = s;
-                v.tcb_status = t;
-                v.advisories = a;
-                v.boot_executables = ex;
+            Ok(av) => {
+                v.ear_status = av.ear_status;
+                v.tcb_status = av.tcb_status;
+                v.advisories = av.advisories;
+                v.boot_executables = av.executables;
             }
             Err(e) => v.note = format!("{}AS: {}", v.note, e),
         }


### PR DESCRIPTION
## Problem
`verify-app` sent empty `policy_ids`, so the AS used its **default** policy and the boot chain (shim/grub/kernel/initrd/kernel_cmdline) was never checked.

## Change
Add `--policy-ids` to select an AS policy (e.g. `0g-tapp`):
- threaded through `verify_app` / `verify_node_direct` / `verify_with_as` into the `AttestationEvaluate` request;
- read the AR4SI `executables` claim from the EAR token and print a `boot-chain` line (✓ when `executables==3`, i.e. the policy's reference values matched);
- the line is shown only when `--policy-ids` is given (otherwise the default policy's `executables` is not our boot-chain check). Empty default keeps current behavior and never errors on an AS lacking the policy.

Pairs with the `0g-tapp` policy in PR for `docs/gcp-measurement-research`.

## Verified (shared AS 47.237.201.184)
- no `--policy-ids` → no boot-chain line;
- `--policy-ids 0g-tapp` (target initrd, not this node) → boot-chain ✗ (executables=33);
- policy whose reference initrd matches the node → boot-chain ✓ (executables=3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)