### PR TITLE
feat: runtime CLI↔server/contract version-compatibility check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5528,6 +5528,7 @@ dependencies = [
  "serde_yaml",
  "sha3",
  "tapp-common",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "tonic",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5512,7 +5512,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tapp-cli"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/contract/CONTRACTS.md
+++ b/contract/CONTRACTS.md
@@ -46,9 +46,16 @@ TAPP_REGISTRY_CONTRACT=0x95a0BF4148b30F6F8D86870534c51df46Da5511c
 | Contract | Address |
 |----------|---------|
 | TappRegistry Implementation (initial) | `0xaeddc6b6A6b9d4a9513Cc2322bbb78DFF97DA459` |
-| **TappRegistry Implementation (current, getNode resolves inherit)** | `0x6987fD9afe6e2430bF5AD85cfBC8c63487d4e4BD` |
+| TappRegistry Implementation (getNode resolves inherit) | `0x6987fD9afe6e2430bF5AD85cfBC8c63487d4e4BD` |
+| **TappRegistry Implementation (current, v0.1.0 — adds `version()`)** | `0x9Ea52Ef383e8eA3fe7F0890309D3C62b2FC1Ac2B` |
 | UpgradeableBeacon | `0x1Cd7544068AdC525b9Cb21cC13aF25D95a53645E` |
 | **BeaconProxy (stable)** | `0x2Ce80374318B1d7Fb3345724457a182E0ad165c9` |
+
+**Upgrades**
+
+| Date | New Implementation | Upgrade Tx | Notes |
+|------|--------------------|-----------|-------|
+| 2026-07-07 | `0x9Ea52Ef383e8eA3fe7F0890309D3C62b2FC1Ac2B` | `0x8a003a1a05c381f59bf213c19e2340b63094ad3230d84e0f42ac9c71d7f84505` | Add `version()` view (baseline `0.1.0`); storage layout unchanged, source-verified |
 
 e2e exercised on app `0g-kms`: register-onchain (app-level default + first node
 inherit), add-node-onchain (per-node override), update-node-onchain — all verified

--- a/contract/src/TappRegistry.sol
+++ b/contract/src/TappRegistry.sol
@@ -170,6 +170,17 @@ contract TappRegistry {
         lockPeriod     = _lockPeriod;
     }
 
+    // ─── Version ──────────────────────────────────────────────────────────────
+
+    /// @notice Implementation version — see docs/VERSIONING.md.
+    /// @dev The proxy address is stable across upgrades, so callers read this to
+    ///      learn the live implementation's ABI version. Bump on every upgrade:
+    ///      MINOR on an ABI change, PATCH on a logic-only (storage-layout-safe)
+    ///      change.
+    function version() external pure returns (string memory) {
+        return "0.1.0";
+    }
+
     // ─── Admin ────────────────────────────────────────────────────────────────
 
     function setMinStakeAmount(uint256 amount) external onlyAdmin {
@@ -412,17 +423,17 @@ contract TappRegistry {
     function _acknowledgeApp(string calldata appId) internal {
         require(_apps[appId].owner != address(0), "app not found");
 
-        uint256 version = _appAckVersions[appId];
-        uint256 prior   = _acks[msg.sender][appId];
-        if (prior == version + 1) return;
+        uint256 ackVersion = _appAckVersions[appId];
+        uint256 prior      = _acks[msg.sender][appId];
+        if (prior == ackVersion + 1) return;
 
-        // Store version+1 so that version==0 (initial) is distinguishable from "never acked"
+        // Store ackVersion+1 so that ackVersion==0 (initial) is distinguishable from "never acked"
         if (prior == 0) {
             _ackCounts[appId]++;
         }
-        _acks[msg.sender][appId] = version + 1;
+        _acks[msg.sender][appId] = ackVersion + 1;
 
-        emit AppAcknowledged(appId, msg.sender, version);
+        emit AppAcknowledged(appId, msg.sender, ackVersion);
     }
 
     function _revokeAcknowledgement(string calldata appId) internal {
@@ -526,8 +537,8 @@ contract TappRegistry {
 
     /// @notice Returns true if the user has acknowledged the current app version.
     function isAcknowledged(address user, string calldata appId) external view returns (bool) {
-        uint256 version = _appAckVersions[appId];
-        return _acks[user][appId] == version + 1;
+        uint256 ackVersion = _appAckVersions[appId];
+        return _acks[user][appId] == ackVersion + 1;
     }
 
     /// @notice Total number of unique users who have ever acknowledged this app.

--- a/contract/test/TappRegistry.t.sol
+++ b/contract/test/TappRegistry.t.sol
@@ -62,6 +62,12 @@ contract TappRegistryTest is Test {
         registry.addNode{value: MIN_STAKE}(APP_ID, node2, TEE_URL_2, hex"", hex"");
     }
 
+    // ─── version ────────────────────────────────────────────────────────────
+
+    function test_Version_ReturnsImplementationVersion() public view {
+        assertEq(registry.version(), "0.1.0");
+    }
+
     // ─── registerApp ──────────────────────────────────────────────────────────
 
     function test_RegisterApp_StoresAppInfo() public {

--- a/tapp-cli/Cargo.toml
+++ b/tapp-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tapp-cli"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 description = "Standalone CLI for TAPP gRPC server and on-chain operations"
 license.workspace = true

--- a/tapp-cli/build.rs
+++ b/tapp-cli/build.rs
@@ -1,0 +1,46 @@
+//! Stamp the gRPC interface version this CLI is built against into the binary.
+//!
+//! The gRPC interface version is the tapp-server `MAJOR.MINOR` (see
+//! `docs/VERSIONING.md`). tapp-cli and tapp-server live in the same workspace,
+//! so we read the server's version straight from the workspace root
+//! `Cargo.toml` at build time — no separate number to maintain. It is exposed
+//! as the `TAPP_EXPECTED_SERVER_VERSION` compile-time env var.
+
+use std::path::Path;
+
+fn main() {
+    let root_manifest = Path::new(env!("CARGO_MANIFEST_DIR")).join("../Cargo.toml");
+    println!("cargo:rerun-if-changed={}", root_manifest.display());
+
+    let text = std::fs::read_to_string(&root_manifest)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", root_manifest.display()));
+
+    let version = package_version(&text).unwrap_or_else(|| {
+        panic!(
+            "could not find [package] version in {}",
+            root_manifest.display()
+        )
+    });
+
+    println!("cargo:rustc-env=TAPP_EXPECTED_SERVER_VERSION={version}");
+}
+
+/// Extract the `version` value from the `[package]` table of a Cargo manifest,
+/// ignoring the `[workspace.package]` table that precedes it.
+fn package_version(manifest: &str) -> Option<String> {
+    let mut in_package = false;
+    for line in manifest.lines() {
+        let line = line.trim();
+        if line.starts_with('[') {
+            in_package = line == "[package]";
+            continue;
+        }
+        if in_package {
+            if let Some(rest) = line.strip_prefix("version") {
+                let value = rest.trim_start().strip_prefix('=')?.trim();
+                return Some(value.trim_matches('"').to_string());
+            }
+        }
+    }
+    None
+}

--- a/tapp-cli/src/main.rs
+++ b/tapp-cli/src/main.rs
@@ -31,7 +31,7 @@ async fn create_client(
         None
     };
 
-    if let Some(path) = unix_path {
+    let client = if let Some(path) = unix_path {
         let channel = tonic::transport::Endpoint::from_static("http://[::]:50051")
             .connect_with_connector(service_fn(move |_: http::Uri| {
                 let path = path.clone();
@@ -41,9 +41,36 @@ async fn create_client(
                 }
             }))
             .await?;
-        Ok(TappServiceClient::new(channel))
+        TappServiceClient::new(channel)
     } else {
-        Ok(TappServiceClient::connect(server.to_string()).await?)
+        TappServiceClient::connect(server.to_string()).await?
+    };
+
+    // Best-effort interface-version check: warn (never fail) if the server's
+    // gRPC interface looks incompatible with what this CLI was built for.
+    warn_if_incompatible(client.clone()).await;
+
+    Ok(client)
+}
+
+/// gRPC interface version this CLI was built against — the tapp-server
+/// `MAJOR.MINOR` (see `docs/VERSIONING.md`), stamped by `build.rs` from the
+/// workspace root `Cargo.toml`.
+const EXPECTED_SERVER_VERSION: &str = env!("TAPP_EXPECTED_SERVER_VERSION");
+
+/// Read the server version via `GetTappInfo` (a public RPC) and print a warning
+/// to stderr if its interface `MAJOR.MINOR` looks incompatible with this CLI.
+/// Any failure is ignored — the invoked command surfaces real connection errors.
+async fn warn_if_incompatible(mut client: TappServiceClient<tonic::transport::Channel>) {
+    if let Ok(resp) = client
+        .get_tapp_info(Request::new(GetTappInfoRequest {}))
+        .await
+    {
+        if let Some(warning) =
+            tapp_common::compat::interface_warning(&resp.get_ref().version, EXPECTED_SERVER_VERSION)
+        {
+            eprintln!("⚠️  {warning}");
+        }
     }
 }
 

--- a/tapp-common/src/compat.rs
+++ b/tapp-common/src/compat.rs
@@ -1,0 +1,75 @@
+//! CLI ↔ server interface-version compatibility check.
+//!
+//! Compatibility is decided on the `MAJOR.MINOR` of the peer's reported version
+//! — `PATCH` never changes the interface, so it is ignored here. See
+//! `docs/VERSIONING.md` for the full policy.
+
+/// Parse the `MAJOR.MINOR` interface identity from a full `X.Y.Z` version
+/// string, ignoring the `PATCH` digit. Returns `None` if the string does not
+/// look like a version.
+fn major_minor(version: &str) -> Option<(u64, u64)> {
+    let mut parts = version.trim().trim_start_matches('v').split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+    Some((major, minor))
+}
+
+/// Compare a peer's reported full version against the interface version this
+/// build was compiled for. Returns a human-readable warning when they may be
+/// incompatible, or `None` when compatible.
+///
+/// Only `MAJOR.MINOR` is considered:
+/// - different `MAJOR` → likely incompatible (different interface major line);
+/// - same `MAJOR`, peer `MINOR` older than expected → newer commands may fail;
+/// - otherwise → compatible (peer is same or newer, additive changes are safe).
+///
+/// If either version cannot be parsed, returns `None` (no spurious warning).
+pub fn interface_warning(peer_version: &str, expected_version: &str) -> Option<String> {
+    let (peer_major, peer_minor) = major_minor(peer_version)?;
+    let (exp_major, exp_minor) = major_minor(expected_version)?;
+
+    if peer_major != exp_major {
+        Some(format!(
+            "server interface v{peer_major}.{peer_minor} is on a different major line than this CLI expects (v{exp_major}.{exp_minor}); they are likely incompatible"
+        ))
+    } else if peer_minor < exp_minor {
+        Some(format!(
+            "server interface v{peer_major}.{peer_minor} is older than this CLI expects (v{exp_major}.{exp_minor}); newer commands may fail"
+        ))
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::interface_warning;
+
+    #[test]
+    fn patch_is_ignored() {
+        assert!(interface_warning("0.2.7", "0.2.1").is_none());
+        assert!(interface_warning("0.2.0", "0.2.9").is_none());
+    }
+
+    #[test]
+    fn newer_server_is_ok() {
+        assert!(interface_warning("0.3.0", "0.2.0").is_none());
+    }
+
+    #[test]
+    fn older_server_minor_warns() {
+        assert!(interface_warning("0.1.0", "0.2.0").is_some());
+    }
+
+    #[test]
+    fn major_mismatch_warns() {
+        assert!(interface_warning("1.0.0", "0.2.0").is_some());
+        assert!(interface_warning("0.9.9", "1.0.0").is_some());
+    }
+
+    #[test]
+    fn unparseable_is_silent() {
+        assert!(interface_warning("", "0.1.0").is_none());
+        assert!(interface_warning("dev", "0.1.0").is_none());
+    }
+}

--- a/tapp-common/src/lib.rs
+++ b/tapp-common/src/lib.rs
@@ -6,6 +6,7 @@ pub mod error;
 pub mod onchain;
 pub mod app_key;
 pub mod verify;
+pub mod compat;
 
 pub mod proto {
     tonic::include_proto!("tapp_service");


### PR DESCRIPTION
Implements the runtime compatibility mechanism defined in `docs/VERSIONING.md` (#25). Builds on the Unix-socket work (#22, now merged).

## gRPC edge (CLI ↔ server)
- **`tapp-common::compat::interface_warning`** — compares `MAJOR.MINOR` only (PATCH never changes the interface), returns a warning string when the peer's interface looks incompatible, `None` otherwise. Unit-tested.
- **`tapp-cli/build.rs`** — stamps the expected server interface version (the workspace-root `tapp-server` `MAJOR.MINOR`) into the binary at build time, so there's no separate number to maintain.
- **`create_client`** does a best-effort `GetTappInfo` on connect and warns to stderr on mismatch. It **never hard-blocks** — a genuinely missing RPC still fails at the call. `GetTappInfo` is a public RPC, so no auth concern.
- Bump **tapp-cli `0.1.0 → 0.1.1`** (adds the on-connect warning behavior).

## On-chain edge (server/CLI ↔ contract)
- Add a **`version()`** view to `TappRegistry` returning `"0.1.0"`, so callers can read the live implementation version behind the stable beacon-proxy address.
- Rename local `version` vars → `ackVersion` to avoid shadowing the new view.
- Added a `version()` test; full suite: **73 passing**.

## No server change
`GetTappInfo` already reports the full `tapp-server` version — the gRPC edge needs nothing new server-side.

## Notes / follow-ups
- The stamped expected-version is intentionally conservative (build-time server `MAJOR.MINOR`); mismatches only warn, so this is harmless. A precise `REQUIRES_SERVER_API` constant is the documented escape hatch if ever needed.
- Bumping the contract implementation on a real upgrade should update the `version()` string per `docs/VERSIONING.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)