### PR TITLE
feat: start-app --register-onchain — idempotent on-chain registration before the app starts

### DIFF
--- a/.claude/skills/0g-tapp-cli/SKILL.md
+++ b/.claude/skills/0g-tapp-cli/SKILL.md
@@ -34,6 +34,11 @@ Record which key maps to which server/owner in memory — it changes per deploym
 ```bash
 tapp-cli -s <server> -k 0x<key> docker-login -r <registry-host> -u <user> -p <password>
 tapp-cli -s <server> -k 0x<key> start-app -f docker-compose.yaml --app-id <id>   # async → task-id
+tapp-cli -s <server> -k 0x<key> start-app -f <compose> --app-id <id> \
+  --register-onchain --rpc-url <rpc> --contract 0x<reg> --stake-wei 1000000000000000000
+  # ↑ idempotent register-BEFORE-start: pulls+measures first, tx confirms, THEN containers start.
+  #   not registered→registerApp; registered but this node's signer missing→addNode; signer present→skip.
+  #   Requires a server with measure_only support; older servers → CLI aborts ("Server did not return measurements").
 tapp-cli -s <server> -k 0x<key> get-task-status --task-id <task-id>
 tapp-cli -s <server> -k 0x<key> stop-app --app-id <id>
 tapp-cli -s <server> -k 0x<key> stop-service  --app-id <id> --service-name <svc>  # flag is --service-name
@@ -92,6 +97,8 @@ A failed task prints the docker compose `Stderr:` (the actual root cause). A com
 `--server` is also recorded on-chain as the node's `teeUrl` (the `:50051` URL). Key must be the app owner (see Keys above).
 
 ```bash
+# Preferred for new deploys: start-app --register-onchain (see Core Commands) registers
+# BEFORE containers start and is idempotent. The commands below register a RUNNING app.
 register-onchain    --app-id <id> --rpc-url <rpc> --contract 0x<reg> --stake-wei 1000000000000000000  # 1 0G
 update-onchain      --app-id <id> --rpc-url <rpc> --contract 0x<reg>                                   # re-fetch hashes after redeploy
 add-node-onchain    --app-id <id> --rpc-url <rpc> --contract 0x<reg> --stake-wei <wei>                 # -s = new node

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5528,6 +5528,7 @@ dependencies = [
  "serde_yaml",
  "sha3",
  "tapp-common",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "tonic",

--- a/README.md
+++ b/README.md
@@ -248,6 +248,30 @@ contract_address = "0x..."
 
 Register your app and TEE nodes on the TappRegistry contract using `tapp-cli`. These commands require `--private-key` (the deployer's Ethereum private key) and `--server` (the tapp gRPC endpoint, used both as the gRPC target and as the on-chain `teeUrl`).
 
+### Register during start (recommended)
+
+`start-app --register-onchain` idempotently registers the app BEFORE its
+containers start: the server pulls the images and computes all hashes first
+(measure-only), the CLI submits the transaction, and only after it confirms are
+the containers started. Safe to re-run:
+
+- app not registered on-chain → `registerApp` (this node becomes the first node)
+- registered, but this node's signer not in the node list → `addNode`
+- signer already a node → skip registration, just start
+
+```bash
+tapp-cli -s http://<tapp>:50051 -k 0x<deployer-key> start-app \
+  -f docker-compose.yml --app-id my-app \
+  --register-onchain \
+  --rpc-url https://evmrpc-testnet.0g.ai \
+  --contract 0x<TappRegistry> \
+  --stake-wei 1000000000000000000
+```
+
+Without `--register-onchain`, `start-app` behaves exactly as before (no chain
+interaction). The standalone commands below remain for registering an app that
+is already running:
+
 ```bash
 # Register a new app (fetches hashes and signerAddress from --server automatically)
 tapp-cli -s http://<tapp>:50051 -k 0x<deployer-key> register-onchain \

--- a/docs/DEPLOY_RUNBOOK.md
+++ b/docs/DEPLOY_RUNBOOK.md
@@ -17,6 +17,10 @@
 | 1 | 配 tapp-server config 的 owner，起 tapp 服务器 | 该 owner key 之后用于所有 start/stop/register | ✅ | ✅ |
 | 2 | `start-app` 起服务 | `PROVIDER_ADDRESS` 必须 == 该 app 的链上 owner；先 `docker-login` 私有 registry；`.env` 的 `TAPP_REGISTRY`/`SETTLEMENT_CONTRACT` 要齐 | ✅ | ✅ |
 | 3 | `register-onchain` 注册上链 | 各质押 1 0G | ✅ | ✅ |
+
+> 步骤 2+3 可合并为一条：`start-app --register-onchain --rpc-url … --contract … --stake-wei …`
+> 会在容器启动**之前**幂等注册（未注册→registerApp；已注册但本节点 signer 不在 node list→addNode；已在→跳过）。
+> server 先 pull 镜像算好 hash，交易确认后才 up；重启后 signer 变的场景会自动走 addNode（旧 node 仍需手动 remove/update）。
 | 4 | `authorizeInvalidator(appId, <SandboxServing 合约地址>)` | 授权兄弟合约 SandboxServing 调 `invalidateAcks`，使改价能作废用户 ack；**必须在第 5 步前** | ✅ | — |
 | 5 | `cmd/provider register` 绑服务到 SandboxServing | 设 `services[provider].appId` + 价格 | ✅ | — |
 
@@ -28,6 +32,11 @@ tapp-cli -s http://<server>:50051 -k 0x<owner-key> start-app -f <compose> --app-
 # 3. 注册上链（key 必须既是 server owner 又是有钱的 app owner）
 tapp-cli -s http://<server>:50051 -k 0x<owner-key> register-onchain \
   --app-id <appId> --rpc-url https://evmrpc-testnet.0g.ai \
+  --contract 0x95a0BF4148b30F6F8D86870534c51df46Da5511c --stake-wei 1000000000000000000
+
+# 2+3 合并版：先注册再起（幂等，可反复跑）
+tapp-cli -s http://<server>:50051 -k 0x<owner-key> start-app -f <compose> --app-id <appId> \
+  --register-onchain --rpc-url https://evmrpc-testnet.0g.ai \
   --contract 0x95a0BF4148b30F6F8D86870534c51df46Da5511c --stake-wei 1000000000000000000
 
 # 4. 授权 invalidator（注意：授权的是 SandboxServing 合约地址，不是 owner 钱包）

--- a/proto/tapp_service.proto
+++ b/proto/tapp_service.proto
@@ -134,6 +134,11 @@ message StartAppRequest {
   string app_id = 2;  // Application identifier for key binding
   repeated MountFile mount_files =
       3;  // Files to mount (mapped by source_path from compose volumes)
+  // Pull images and compute measurements (compose/volumes/image hashes)
+  // WITHOUT starting containers. Used by the CLI to register the app
+  // on-chain before it actually runs; a follow-up StartApp (without this
+  // flag) then starts the containers from the cached images.
+  bool measure_only = 4;
 }
 
 message StartAppResponse {
@@ -163,6 +168,10 @@ message TaskResult {
   string app_id = 1;    // Application identifier (on success)
   string deployer = 2;  // Deployer EVM address (on success)
   string error = 3;     // Error message (on failure)
+  // Measurements, set only for measure_only tasks (see StartAppRequest).
+  string compose_hash = 4;                // Hash of compose file content
+  map<string, string> volumes_hash = 5;   // Map: file_name -> hash
+  map<string, string> image_hash = 6;     // Map: service_name -> image digest
 }
 
 message GetTaskStatusResponse {

--- a/src/boot/manager.rs
+++ b/src/boot/manager.rs
@@ -136,17 +136,13 @@ impl DockerComposeManager {
         Ok(source_to_host)
     }
 
-    /// Deploy Docker Compose application
-    pub async fn deploy_compose(
+    /// Store the compose file and mount files into the app directory.
+    /// Shared staging step for deploy_compose and pull_and_measure.
+    async fn stage_app_files(
         app_id: &str,
         compose_content: &str,
         mount_files: &[MountFile],
-    ) -> TappResult<std::collections::BTreeMap<String, String>> {
-        use std::sync::Arc;
-        use tokio::io::{AsyncBufReadExt, BufReader};
-        use tokio::sync::Mutex;
-
-        // 1. store compose file
+    ) -> TappResult<PathBuf> {
         let base_path = Self::get_app_dir(app_id);
         if !base_path.exists() {
             fs::create_dir_all(&base_path).await.map_err(|e| {
@@ -158,8 +154,99 @@ impl DockerComposeManager {
         let compose_path = base_path.join("docker-compose.yml");
         fs::write(&compose_path, compose_content).await?;
 
-        // 2. store mount files to corresponding location
         Self::store_mount_files(&base_path, mount_files).await?;
+        Ok(base_path)
+    }
+
+    /// Pull images and return their digests WITHOUT starting containers.
+    /// Stages the app files, runs `docker compose pull`, then resolves each
+    /// service's image digest. Used to register an app on-chain before it runs;
+    /// the follow-up deploy_compose starts containers from the cached images.
+    pub async fn pull_and_measure(
+        app_id: &str,
+        compose_content: &str,
+        mount_files: &[MountFile],
+    ) -> TappResult<std::collections::BTreeMap<String, String>> {
+        let base_path = Self::stage_app_files(app_id, compose_content, mount_files).await?;
+
+        info!(app_id = %app_id, "📥 Pulling images (measure-only, containers not started)");
+        let output = Command::new("docker")
+            .current_dir(&base_path)
+            .args(["compose", "-f", "docker-compose.yml", "pull"])
+            .output()
+            .await
+            .map_err(|e| DockerError::ContainerOperationFailed {
+                operation: "docker_compose_pull".to_string(),
+                reason: format!("Failed to execute docker compose pull: {}", e),
+            })?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            error!(app_id = %app_id, stderr = %stderr, "❌ Docker compose pull failed");
+            return Err(DockerError::ContainerOperationFailed {
+                operation: "docker_compose_pull".to_string(),
+                reason: format!(
+                    "Docker compose pull failed with exit code {:?}\nStderr: {}",
+                    output.status.code(),
+                    stderr
+                ),
+            }
+            .into());
+        }
+
+        // Resolve service -> image digest from the pulled (local) images
+        let mut image_map = std::collections::BTreeMap::new();
+        for (service, image) in Self::compose_service_images(compose_content)? {
+            let digest = Self::get_image_digest(&image).await.unwrap_or_else(|e| {
+                warn!(service = %service, image = %image, error = %e, "Failed to get image digest");
+                String::new()
+            });
+            image_map.insert(service, digest);
+        }
+
+        info!(
+            app_id = %app_id,
+            image_count = image_map.len(),
+            "📦 Measured image digests without starting containers"
+        );
+        Ok(image_map)
+    }
+
+    /// Parse service_name -> image reference from compose content.
+    /// Services without an `image` key (e.g. build-only) are skipped.
+    fn compose_service_images(compose_content: &str) -> TappResult<Vec<(String, String)>> {
+        let compose: serde_yaml::Value =
+            serde_yaml::from_str(compose_content).map_err(|e| TappError::InvalidParameter {
+                field: "compose_content".to_string(),
+                reason: format!("Failed to parse compose file: {}", e),
+            })?;
+
+        let mut result = Vec::new();
+        if let Some(services) = compose.get("services").and_then(|s| s.as_mapping()) {
+            for (name, service) in services {
+                if let (Some(name), Some(image)) = (
+                    name.as_str(),
+                    service.get("image").and_then(|i| i.as_str()),
+                ) {
+                    result.push((name.to_string(), image.to_string()));
+                }
+            }
+        }
+        Ok(result)
+    }
+
+    /// Deploy Docker Compose application
+    pub async fn deploy_compose(
+        app_id: &str,
+        compose_content: &str,
+        mount_files: &[MountFile],
+    ) -> TappResult<std::collections::BTreeMap<String, String>> {
+        use std::sync::Arc;
+        use tokio::io::{AsyncBufReadExt, BufReader};
+        use tokio::sync::Mutex;
+
+        // 1-2. store compose file and mount files
+        let base_path = Self::stage_app_files(app_id, compose_content, mount_files).await?;
 
         // 3. start compose with real-time output
         info!(app_id = %app_id, "🚀 Starting docker compose up");

--- a/src/boot/mod.rs
+++ b/src/boot/mod.rs
@@ -144,6 +144,63 @@ enable_eventlog = true
             })
             .collect();
 
+        // Measure-only: pull images and compute hashes, but don't start containers.
+        // Result (compose/volumes/image hashes) is returned via the task result so
+        // the CLI can register the app on-chain before actually starting it.
+        if request.measure_only {
+            let image_hash = match DockerComposeManager::pull_and_measure(
+                &app_id,
+                &request.compose_content,
+                &mount_files,
+            )
+            .await
+            {
+                Ok(map) => map,
+                Err(e) => {
+                    self.task_manager
+                        .mark_failed(&task_id, format!("Failed to pull/measure images: {}", e))
+                        .await;
+                    return;
+                }
+            };
+
+            let measurement = match self
+                .calculate_app_measurement(
+                    &request,
+                    &mount_files,
+                    &app_id,
+                    &deployer,
+                    crate::measurement_service::OPERATION_NAME_START_APP,
+                    image_hash.clone(),
+                )
+                .await
+            {
+                Ok((m, _, _)) => m,
+                Err(e) => {
+                    self.task_manager
+                        .mark_failed(&task_id, format!("Failed to calculate measurement: {}", e))
+                        .await;
+                    return;
+                }
+            };
+
+            // Note: no extend_measurement and no AppInfo registration here — the
+            // app has not run; the follow-up real StartApp does both as usual.
+            self.task_manager
+                .mark_completed(
+                    &task_id,
+                    TaskSuccessResult {
+                        app_id,
+                        deployer,
+                        compose_hash: measurement.compose_hash,
+                        volumes_hash: measurement.volumes_hash,
+                        image_hash,
+                    },
+                )
+                .await;
+            return;
+        }
+
         // Try to start the application
         let deploy_result = async {
             info!(
@@ -279,7 +336,10 @@ enable_eventlog = true
 
                 // Mark task as completed
                 self.task_manager
-                    .mark_completed(&task_id, TaskSuccessResult { app_id, deployer })
+                    .mark_completed(
+                        &task_id,
+                        TaskSuccessResult { app_id, deployer, ..Default::default() },
+                    )
                     .await;
             }
             Err(e) => {
@@ -1039,6 +1099,7 @@ enable_eventlog = true
                         TaskSuccessResult {
                             app_id,
                             deployer: app_info.owner,
+                            ..Default::default()
                         },
                     )
                     .await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -362,13 +362,20 @@ impl TappService for TappServiceImpl {
         //     &req.key_type
         // };
 
-        let response = self.app_key_service.get_public_key(&req.app_id).await?;
+        // Create-if-missing (same as GetEvidence): allows fetching the signer
+        // address BEFORE the app starts, e.g. for on-chain pre-registration.
+        // The key lives in this process's memory, so the app gets the same key
+        // when it actually starts.
+        let key_pair = self
+            .app_key_service
+            .get_app_key(&req.app_id, "ethereum", req.x25519)
+            .await?;
         Ok(Response::new(GetAppKeyResponse {
             success: true,
             message: format!("Public key for app {}", req.app_id),
-            eth_address: response.0,
-            public_key: response.1,
-            x25519_public_key: response.2.unwrap_or_default(),
+            eth_address: key_pair.eth_address,
+            public_key: key_pair.public_key,
+            x25519_public_key: key_pair.x25519_public_key.unwrap_or_default(),
             key_source: "in-memory".to_string(),
         }))
     }

--- a/src/task_manager.rs
+++ b/src/task_manager.rs
@@ -12,10 +12,14 @@ pub enum TaskStatus {
     Failed(String),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct TaskSuccessResult {
     pub app_id: String,
     pub deployer: String, // EVM address from signature authentication
+    // Measurements, populated only by measure-only StartApp tasks
+    pub compose_hash: String,
+    pub volumes_hash: std::collections::BTreeMap<String, String>, // file_name -> hash
+    pub image_hash: std::collections::BTreeMap<String, String>,   // service_name -> digest
 }
 
 #[derive(Debug, Clone)]
@@ -52,11 +56,17 @@ impl Task {
                 app_id: result.app_id.clone(),
                 deployer: result.deployer.clone(),
                 error: String::new(),
+                compose_hash: result.compose_hash.clone(),
+                volumes_hash: result.volumes_hash.clone().into_iter().collect(),
+                image_hash: result.image_hash.clone().into_iter().collect(),
             }),
             TaskStatus::Failed(error) => Some(TaskResult {
                 app_id: String::new(),
                 deployer: String::new(),
                 error: error.clone(),
+                compose_hash: String::new(),
+                volumes_hash: Default::default(),
+                image_hash: Default::default(),
             }),
             _ => None,
         }

--- a/tapp-cli/src/main.rs
+++ b/tapp-cli/src/main.rs
@@ -78,6 +78,26 @@ enum Commands {
         /// Application ID
         #[arg(short, long)]
         app_id: String,
+
+        /// Idempotently ensure the app is registered on-chain BEFORE it starts:
+        /// not registered -> registerApp; registered but this node's signer is
+        /// not in the node list -> addNode; signer already a node -> skip.
+        /// Images are pulled and measured first; containers only start after
+        /// the transaction is confirmed.
+        #[arg(long, requires_all = ["rpc_url", "contract", "stake_wei"])]
+        register_onchain: bool,
+
+        /// Ethereum RPC URL (with --register-onchain)
+        #[arg(long)]
+        rpc_url: Option<String>,
+
+        /// TappRegistry contract address 0x... (with --register-onchain)
+        #[arg(long)]
+        contract: Option<String>,
+
+        /// Stake in wei for registerApp/addNode, >= minStakeAmount (with --register-onchain)
+        #[arg(long)]
+        stake_wei: Option<u128>,
     },
 
     /// Stop a running application
@@ -517,8 +537,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Commands::StartApp {
             compose_file,
             app_id,
+            register_onchain,
+            rpc_url,
+            contract,
+            stake_wei,
         } => {
             let private_key = require_private_key(&cli.private_key)?;
+            if register_onchain {
+                // requires_all guarantees these are present
+                ensure_registered_onchain(
+                    &cli.server,
+                    &compose_file,
+                    &app_id,
+                    rpc_url.unwrap(),
+                    contract.unwrap(),
+                    stake_wei.unwrap(),
+                    &private_key,
+                )
+                .await?;
+            }
             start_app(&cli.server, compose_file, app_id, private_key).await?;
         }
         Commands::StopApp { app_id } => {
@@ -884,48 +921,210 @@ fn extract_volume_mounts(
     Ok(mount_files)
 }
 
+/// Send a StartApp request (optionally measure-only) and return the task id.
+async fn send_start_app(
+    server: &str,
+    compose_file: &PathBuf,
+    app_id: &str,
+    private_key: &str,
+    measure_only: bool,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let mut client = create_client(server).await?;
+
+    // Read compose file
+    let compose_content = std::fs::read_to_string(compose_file)?;
+
+    // Auto-extract volume mounts from compose file
+    let mount_files = extract_volume_mounts(compose_file, &compose_content)?;
+
+    // Create authenticated request with signature
+    let mut request = Request::new(StartAppRequest {
+        compose_content,
+        app_id: app_id.to_owned(),
+        mount_files,
+        measure_only,
+    });
+
+    // Add signature metadata
+    add_signature_metadata(&mut request, private_key, "StartApp")?;
+
+    let response = client.start_app(request).await?;
+    let result = response.into_inner();
+    if !result.success {
+        return Err(format!("StartApp request failed: {}", result.message).into());
+    }
+    Ok(result.task_id)
+}
+
 async fn start_app(
     server: &str,
     compose_file: PathBuf,
     app_id: String,
     private_key: String,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let mut client = create_client(server).await?;
-
-    // Read compose file
-    let compose_content = std::fs::read_to_string(&compose_file)?;
-
-    // Auto-extract volume mounts from compose file
-    let mount_files = extract_volume_mounts(&compose_file, &compose_content)?;
-
-    // Create authenticated request with signature
-    let mut request = Request::new(StartAppRequest {
-        compose_content,
-        app_id: app_id.clone(),
-        mount_files,
-    });
-
-    // Add signature metadata
-    add_signature_metadata(&mut request, &private_key, "StartApp")?;
-
-    let response = client.start_app(request).await?;
-    let result = response.into_inner();
+    let task_id = send_start_app(server, &compose_file, &app_id, &private_key, false).await?;
 
     println!("✓ Application start requested");
     println!("  App ID: {}", app_id);
-    println!("  Task ID: {}", result.task_id);
-    println!("  Message: {}", result.message);
+    println!("  Task ID: {}", task_id);
 
     // Show command to check progress with server parameter if not using default
     let check_command = if server == "http://127.0.0.1:50051" {
-        format!("tapp-cli get-task-status --task-id {}", result.task_id)
+        format!("tapp-cli get-task-status --task-id {}", task_id)
     } else {
         format!(
             "tapp-cli --server {} get-task-status --task-id {}",
-            server, result.task_id
+            server, task_id
         )
     };
     println!("\nUse '{}' to check progress", check_command);
+
+    Ok(())
+}
+
+/// Poll a task until it completes (returning its result) or fails.
+async fn wait_for_task(
+    server: &str,
+    task_id: &str,
+    timeout_secs: u64,
+) -> Result<tapp_common::proto::TaskResult, Box<dyn std::error::Error>> {
+    let mut client = create_client(server).await?;
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
+
+    loop {
+        let resp = client
+            .get_task_status(Request::new(GetTaskStatusRequest {
+                task_id: task_id.to_owned(),
+            }))
+            .await?
+            .into_inner();
+        // Note: resp.success is true ONLY for completed tasks; pending/running
+        // also report success=false, so branch on status instead.
+        if resp.created_at == 0 {
+            return Err(format!("GetTaskStatus failed: {}", resp.message).into());
+        }
+        match resp.status {
+            2 => return Ok(resp.result.unwrap_or_default()), // Completed
+            3 => {
+                let error = resp.result.map(|r| r.error).unwrap_or_default();
+                return Err(format!("Task {} failed: {}", task_id, error).into());
+            }
+            _ => {
+                if std::time::Instant::now() > deadline {
+                    return Err(format!(
+                        "Timed out after {}s waiting for task {}",
+                        timeout_secs, task_id
+                    )
+                    .into());
+                }
+                tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+            }
+        }
+    }
+}
+
+/// Idempotently make sure the app is registered on-chain BEFORE it starts:
+/// - app not registered            -> measure + registerApp (this node = first node)
+/// - registered, signer not a node -> measure + addNode
+/// - signer already a node         -> no-op
+/// "Measure" = a measure_only StartApp: the server pulls images and computes
+/// compose/volumes/image hashes without starting containers.
+async fn ensure_registered_onchain(
+    server: &str,
+    compose_file: &PathBuf,
+    app_id: &str,
+    rpc_url: String,
+    contract: String,
+    stake_wei: u128,
+    private_key: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use ethers::signers::Signer;
+    use ethers::types::{Address, U256};
+    use tapp_common::onchain::{self, OnchainParams};
+
+    let signer = fetch_signer_address(server, app_id).await?;
+    let owner = onchain::get_app_owner(&rpc_url, &contract, app_id).await?;
+
+    let is_first_node = if owner == Address::zero() {
+        true
+    } else {
+        let key_bytes = hex::decode(private_key.trim_start_matches("0x"))
+            .map_err(|e| format!("Invalid private key: {}", e))?;
+        let wallet = ethers::signers::LocalWallet::from_bytes(&key_bytes)
+            .map_err(|e| format!("Invalid private key: {}", e))?;
+        if owner != wallet.address() {
+            return Err(format!(
+                "App {} is owned by 0x{:x} on-chain, but the provided key is 0x{:x}",
+                app_id,
+                owner,
+                wallet.address()
+            )
+            .into());
+        }
+        let nodes = onchain::get_node_list(&rpc_url, &contract, app_id).await?;
+        if nodes.contains(&signer) {
+            println!(
+                "✓ Already registered on-chain (signer 0x{:x} is in the node list), skipping",
+                signer
+            );
+            return Ok(());
+        }
+        false
+    };
+
+    // Measure without starting: pull images, compute hashes
+    println!("⏳ Measuring app before on-chain registration (pulling images)...");
+    let task_id = send_start_app(server, compose_file, app_id, private_key, true).await?;
+    let measured = wait_for_task(server, &task_id, 900).await?;
+
+    // An old server ignores measure_only (unknown proto field) and returns no
+    // measurements — registering empty hashes would be silently wrong.
+    if measured.compose_hash.is_empty() {
+        return Err(
+            "Server did not return measurements: it likely predates measure_only support. \
+             Upgrade tapp-server or register with the standalone register-onchain command."
+                .into(),
+        );
+    }
+
+    let compose_hash = onchain::hex_to_bytes(&measured.compose_hash)?;
+    let volumes_hash = onchain::combine_map_hashes(&measured.volumes_hash);
+    let image_hashes = onchain::map_to_bytes_array(&measured.image_hash);
+
+    let params = OnchainParams { rpc_url: rpc_url.clone(), contract: contract.clone(), private_key: private_key.to_owned() };
+    if is_first_node {
+        let tx = onchain::register_app(
+            &params,
+            app_id,
+            compose_hash,
+            volumes_hash,
+            image_hashes,
+            signer,
+            server, // recorded on-chain as the node's evidence URL
+            U256::from(stake_wei),
+        )
+        .await?;
+        println!("✓ App registered on-chain");
+        println!("  Signer Address: 0x{:x}", signer);
+        println!("  Tx Hash: 0x{:x}", tx);
+    } else {
+        // Store a per-node override only when it differs from the app-level default
+        let (compose_override, volumes_override) =
+            node_override_hashes(&rpc_url, &contract, app_id, compose_hash, volumes_hash).await?;
+        let tx = onchain::add_node(
+            &params,
+            app_id,
+            signer,
+            server,
+            compose_override,
+            volumes_override,
+            U256::from(stake_wei),
+        )
+        .await?;
+        println!("✓ Node added on-chain");
+        println!("  Signer Address: 0x{:x}", signer);
+        println!("  Tx Hash: 0x{:x}", tx);
+    }
 
     Ok(())
 }

--- a/tapp-common/proto/tapp_service.proto
+++ b/tapp-common/proto/tapp_service.proto
@@ -134,6 +134,11 @@ message StartAppRequest {
   string app_id = 2;  // Application identifier for key binding
   repeated MountFile mount_files =
       3;  // Files to mount (mapped by source_path from compose volumes)
+  // Pull images and compute measurements (compose/volumes/image hashes)
+  // WITHOUT starting containers. Used by the CLI to register the app
+  // on-chain before it actually runs; a follow-up StartApp (without this
+  // flag) then starts the containers from the cached images.
+  bool measure_only = 4;
 }
 
 message StartAppResponse {
@@ -163,6 +168,10 @@ message TaskResult {
   string app_id = 1;    // Application identifier (on success)
   string deployer = 2;  // Deployer EVM address (on success)
   string error = 3;     // Error message (on failure)
+  // Measurements, set only for measure_only tasks (see StartAppRequest).
+  string compose_hash = 4;                // Hash of compose file content
+  map<string, string> volumes_hash = 5;   // Map: file_name -> hash
+  map<string, string> image_hash = 6;     // Map: service_name -> image digest
 }
 
 message GetTaskStatusResponse {

--- a/tapp-common/src/onchain.rs
+++ b/tapp-common/src/onchain.rs
@@ -108,6 +108,27 @@ pub async fn get_app_image_hashes(
     Err(anyhow!("unexpected getAppInfo return shape"))
 }
 
+/// The app owner via getAppInfo(string). Address::zero() means "not registered"
+/// (the contract returns an empty struct for unknown app ids).
+pub async fn get_app_owner(rpc_url: &str, contract: &str, app_id: &str) -> Result<Address> {
+    let data = calldata("getAppInfo(string)", vec![Token::String(app_id.to_owned())]);
+    let out = call_raw(rpc_url, contract, data).await?;
+    let tuple = ParamType::Tuple(vec![
+        ParamType::Bytes,
+        ParamType::Bytes,
+        ParamType::Array(Box::new(ParamType::Bytes)),
+        ParamType::Address,
+        ParamType::Uint(256),
+    ]);
+    let tokens = decode(&[tuple], &out).map_err(|e| anyhow!("decode getAppInfo: {}", e))?;
+    if let Some(Token::Tuple(fields)) = tokens.into_iter().next() {
+        if let Token::Address(owner) = &fields[3] {
+            return Ok(*owner);
+        }
+    }
+    Err(anyhow!("unexpected getAppInfo return shape"))
+}
+
 /// Registered node signer addresses for an app (getNodeList).
 pub async fn get_node_list(rpc_url: &str, contract: &str, app_id: &str) -> Result<Vec<Address>> {
     let data = calldata("getNodeList(string)", vec![Token::String(app_id.to_owned())]);


### PR DESCRIPTION
## What

Adds an optional `--register-onchain` flag to `tapp-cli start-app` (with `--rpc-url` / `--contract` / `--stake-wei`, enforced together). When set, the app is idempotently registered in TappRegistry **before** its containers start:

- app not registered on-chain → `registerApp` (this node becomes the first node)
- registered, but this node's signer not in the node list → `addNode` (per-node override only if hashes differ from app defaults, else inherit)
- signer already a node → skip registration, just start

Without the flag, `start-app` behavior is unchanged.

## How

- **proto**: `StartAppRequest.measure_only` — server stages compose/mount files, `docker compose pull`s images and computes compose/volumes/image hashes **without starting containers**; hashes are returned via new `TaskResult` fields (`compose_hash`, `volumes_hash`, `image_hash`).
- **server**: `pull_and_measure` path in `DockerComposeManager` (shared file-staging extracted into `stage_app_files`); no `extend_measurement` and no AppInfo registration on the measure-only pass — the follow-up real StartApp does both as usual.
- **`GetAppKey` is now create-if-missing** (same as `GetEvidence`), so the signer address is available before the app starts; the key lives in server memory, so the app gets the same key when it runs.
- **CLI**: orchestrates check-chain → measure → register/addNode (waits for tx receipt) → normal start. Guards against old servers: if the task result carries no measurements (server ignored `measure_only`), abort instead of registering empty hashes.
- Also fixes task polling: `GetTaskStatus.success` is true only for *completed* tasks, so the poller branches on `status` instead.

## Tested (0G Galileo testnet, real txs)

- **registerApp path**: measure → register (tx confirmed) → containers start; verified on-chain via `cast`: node list = pre-created signer, SHA384 composeHash, real alpine image digest, correct owner.
- **addNode path**: restarted the tapp-server (new in-memory signer) and re-ran the same command → `addNode` fired, node inherits app-level defaults (`getNode` resolves to identical hashes, empty override stored).
- **idempotent skip**: stop + re-run with flag → "Already registered … skipping", no second tx, containers start.
- All throwaway test registrations removed afterwards (`removeNode`, node lists empty).

Unit tests pass for `tapp-common` / `tapp-cli`; workspace `cargo check` clean. (`cargo test` for the server lib is already broken on dev — `kms_client.rs` tests call the old `KmsClient::new` signature — untouched here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)