### PR TITLE
release: dev → main (version-compat check, start-app --register-onchain, GCP Stage C, start-service idempotency, log retention, KMS material passthrough)

### DIFF
--- a/.claude/skills/0g-tapp-cli/SKILL.md
+++ b/.claude/skills/0g-tapp-cli/SKILL.md
@@ -34,6 +34,11 @@ Record which key maps to which server/owner in memory — it changes per deploym
 ```bash
 tapp-cli -s <server> -k 0x<key> docker-login -r <registry-host> -u <user> -p <password>
 tapp-cli -s <server> -k 0x<key> start-app -f docker-compose.yaml --app-id <id>   # async → task-id
+tapp-cli -s <server> -k 0x<key> start-app -f <compose> --app-id <id> \
+  --register-onchain --rpc-url <rpc> --contract 0x<reg> --stake-wei 1000000000000000000
+  # ↑ idempotent register-BEFORE-start: pulls+measures first, tx confirms, THEN containers start.
+  #   not registered→registerApp; registered but this node's signer missing→addNode; signer present→skip.
+  #   Requires a server with measure_only support; older servers → CLI aborts ("Server did not return measurements").
 tapp-cli -s <server> -k 0x<key> get-task-status --task-id <task-id>
 tapp-cli -s <server> -k 0x<key> stop-app --app-id <id>
 tapp-cli -s <server> -k 0x<key> stop-service  --app-id <id> --service-name <svc>  # flag is --service-name
@@ -92,6 +97,8 @@ A failed task prints the docker compose `Stderr:` (the actual root cause). A com
 `--server` is also recorded on-chain as the node's `teeUrl` (the `:50051` URL). Key must be the app owner (see Keys above).
 
 ```bash
+# Preferred for new deploys: start-app --register-onchain (see Core Commands) registers
+# BEFORE containers start and is idempotent. The commands below register a RUNNING app.
 register-onchain    --app-id <id> --rpc-url <rpc> --contract 0x<reg> --stake-wei 1000000000000000000  # 1 0G
 update-onchain      --app-id <id> --rpc-url <rpc> --contract 0x<reg>                                   # re-fetch hashes after redeploy
 add-node-onchain    --app-id <id> --rpc-url <rpc> --contract 0x<reg> --stake-wei <wei>                 # -s = new node

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5512,7 +5512,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tapp-cli"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5528,6 +5528,7 @@ dependencies = [
  "serde_yaml",
  "sha3",
  "tapp-common",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "tonic",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5512,7 +5512,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tapp-cli"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5562,7 +5562,7 @@ dependencies = [
 
 [[package]]
 name = "tapp-server"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [package]
 name = "tapp-server"
-version = "0.1.1"
+version = "0.2.0"
 edition.workspace = true
 authors = ["TDX TAPP Developers"]
 description = "TDX Trusted Application Platform Service - Rust Implementation"

--- a/README.md
+++ b/README.md
@@ -229,13 +229,15 @@ socket_path = "/var/run/docker.sock"
 
 [logging]
 level = "info"
-path = "/var/log/tapp/"
+format = "pretty"              # "json" or "pretty"
+file_path = "/var/log/tapp/"   # daily-rotated files; on RAM-rootfs CVM images use the persistent disk, e.g. /data/log/tapp/
+max_log_files = 7              # rotated daily files to keep; oldest deleted at startup and rotation (default: 7)
 
 # Optional: KMS cluster for hardware-independent app secrets
-[kms]
-cluster_urls = [
-    "http://kms-node-1:8080",
-    "http://kms-node-2:8080",
+[kbs]
+node_urls = [
+    "http://kms-node-1:9091",
+    "http://kms-node-2:9091",
 ]
 
 # Optional: on-chain TappRegistry integration
@@ -363,7 +365,7 @@ tapp-cli -k 0x<owner-key> revoke-invalidator-onchain \
 
 ## KMS Integration
 
-When `[kms]` is configured, apps running inside the TEE can retrieve a hardware-independent, KMS-derived secret via the `GetSecretResource` gRPC call. This call is **local access only** (localhost / same-host Docker network).
+When `[kbs]` is configured, apps running inside the TEE can retrieve a hardware-independent, KMS-derived secret via the `GetSecretResource` gRPC call. This call is **local access only** (localhost / same-host Docker network).
 
 ### Local key retrieval: Unix socket (recommended)
 
@@ -409,3 +411,15 @@ grpcurl -plaintext -d '{"app_id": "my-app"}' host.docker.internal:50051 tapp_ser
 ```
 
 The returned `secret` bytes are the HKDF-derived app key from the KMS cluster, decrypted inside the TEE. The KMS authenticates the request by verifying the TEE node's on-chain registered `signerAddress`.
+
+### Derivation material (per-caller keys)
+
+`GetSecretResourceRequest` takes an optional `material` field — hex-encoded derivation material, opaque to tapp and forwarded verbatim to the KMS `/app-key` endpoint, which binds it into the derived key alongside `app_id`. This lets an app derive many independent keys from the KMS (e.g. AgenticID derives per-agent seal keys with `material = chainId ‖ contractAddress ‖ sealId`) instead of holding one app-wide secret and deriving locally. The KMS DPRF is one-way: per-material keys expose neither each other nor the app-wide key.
+
+```bash
+grpcurl -unix -plaintext \
+  -d '{"app_id": "my-app", "material": "deadbeef01"}' \
+  /run/tapp/tapp.sock tapp_service.TappService/GetSecretResource
+```
+
+Absent/empty `material` derives purely from the `app_id` namespace — byte-identical to the pre-material request, so existing callers and older KMS nodes are unaffected.

--- a/README.md
+++ b/README.md
@@ -248,6 +248,30 @@ contract_address = "0x..."
 
 Register your app and TEE nodes on the TappRegistry contract using `tapp-cli`. These commands require `--private-key` (the deployer's Ethereum private key) and `--server` (the tapp gRPC endpoint, used both as the gRPC target and as the on-chain `teeUrl`).
 
+### Register during start (recommended)
+
+`start-app --register-onchain` idempotently registers the app BEFORE its
+containers start: the server pulls the images and computes all hashes first
+(measure-only), the CLI submits the transaction, and only after it confirms are
+the containers started. Safe to re-run:
+
+- app not registered on-chain → `registerApp` (this node becomes the first node)
+- registered, but this node's signer not in the node list → `addNode`
+- signer already a node → skip registration, just start
+
+```bash
+tapp-cli -s http://<tapp>:50051 -k 0x<deployer-key> start-app \
+  -f docker-compose.yml --app-id my-app \
+  --register-onchain \
+  --rpc-url https://evmrpc-testnet.0g.ai \
+  --contract 0x<TappRegistry> \
+  --stake-wei 1000000000000000000
+```
+
+Without `--register-onchain`, `start-app` behaves exactly as before (no chain
+interaction). The standalone commands below remain for registering an app that
+is already running:
+
 ```bash
 # Register a new app (fetches hashes and signerAddress from --server automatically)
 tapp-cli -s http://<tapp>:50051 -k 0x<deployer-key> register-onchain \

--- a/contract/CONTRACTS.md
+++ b/contract/CONTRACTS.md
@@ -46,9 +46,16 @@ TAPP_REGISTRY_CONTRACT=0x95a0BF4148b30F6F8D86870534c51df46Da5511c
 | Contract | Address |
 |----------|---------|
 | TappRegistry Implementation (initial) | `0xaeddc6b6A6b9d4a9513Cc2322bbb78DFF97DA459` |
-| **TappRegistry Implementation (current, getNode resolves inherit)** | `0x6987fD9afe6e2430bF5AD85cfBC8c63487d4e4BD` |
+| TappRegistry Implementation (getNode resolves inherit) | `0x6987fD9afe6e2430bF5AD85cfBC8c63487d4e4BD` |
+| **TappRegistry Implementation (current, v0.1.0 — adds `version()`)** | `0x9Ea52Ef383e8eA3fe7F0890309D3C62b2FC1Ac2B` |
 | UpgradeableBeacon | `0x1Cd7544068AdC525b9Cb21cC13aF25D95a53645E` |
 | **BeaconProxy (stable)** | `0x2Ce80374318B1d7Fb3345724457a182E0ad165c9` |
+
+**Upgrades**
+
+| Date | New Implementation | Upgrade Tx | Notes |
+|------|--------------------|-----------|-------|
+| 2026-07-07 | `0x9Ea52Ef383e8eA3fe7F0890309D3C62b2FC1Ac2B` | `0x8a003a1a05c381f59bf213c19e2340b63094ad3230d84e0f42ac9c71d7f84505` | Add `version()` view (baseline `0.1.0`); storage layout unchanged, source-verified |
 
 e2e exercised on app `0g-kms`: register-onchain (app-level default + first node
 inherit), add-node-onchain (per-node override), update-node-onchain — all verified

--- a/contract/src/TappRegistry.sol
+++ b/contract/src/TappRegistry.sol
@@ -170,6 +170,17 @@ contract TappRegistry {
         lockPeriod     = _lockPeriod;
     }
 
+    // ─── Version ──────────────────────────────────────────────────────────────
+
+    /// @notice Implementation version — see docs/VERSIONING.md.
+    /// @dev The proxy address is stable across upgrades, so callers read this to
+    ///      learn the live implementation's ABI version. Bump on every upgrade:
+    ///      MINOR on an ABI change, PATCH on a logic-only (storage-layout-safe)
+    ///      change.
+    function version() external pure returns (string memory) {
+        return "0.1.0";
+    }
+
     // ─── Admin ────────────────────────────────────────────────────────────────
 
     function setMinStakeAmount(uint256 amount) external onlyAdmin {
@@ -412,17 +423,17 @@ contract TappRegistry {
     function _acknowledgeApp(string calldata appId) internal {
         require(_apps[appId].owner != address(0), "app not found");
 
-        uint256 version = _appAckVersions[appId];
-        uint256 prior   = _acks[msg.sender][appId];
-        if (prior == version + 1) return;
+        uint256 ackVersion = _appAckVersions[appId];
+        uint256 prior      = _acks[msg.sender][appId];
+        if (prior == ackVersion + 1) return;
 
-        // Store version+1 so that version==0 (initial) is distinguishable from "never acked"
+        // Store ackVersion+1 so that ackVersion==0 (initial) is distinguishable from "never acked"
         if (prior == 0) {
             _ackCounts[appId]++;
         }
-        _acks[msg.sender][appId] = version + 1;
+        _acks[msg.sender][appId] = ackVersion + 1;
 
-        emit AppAcknowledged(appId, msg.sender, version);
+        emit AppAcknowledged(appId, msg.sender, ackVersion);
     }
 
     function _revokeAcknowledgement(string calldata appId) internal {
@@ -526,8 +537,8 @@ contract TappRegistry {
 
     /// @notice Returns true if the user has acknowledged the current app version.
     function isAcknowledged(address user, string calldata appId) external view returns (bool) {
-        uint256 version = _appAckVersions[appId];
-        return _acks[user][appId] == version + 1;
+        uint256 ackVersion = _appAckVersions[appId];
+        return _acks[user][appId] == ackVersion + 1;
     }
 
     /// @notice Total number of unique users who have ever acknowledged this app.

--- a/contract/test/TappRegistry.t.sol
+++ b/contract/test/TappRegistry.t.sol
@@ -62,6 +62,12 @@ contract TappRegistryTest is Test {
         registry.addNode{value: MIN_STAKE}(APP_ID, node2, TEE_URL_2, hex"", hex"");
     }
 
+    // ─── version ────────────────────────────────────────────────────────────
+
+    function test_Version_ReturnsImplementationVersion() public view {
+        assertEq(registry.version(), "0.1.0");
+    }
+
     // ─── registerApp ──────────────────────────────────────────────────────────
 
     function test_RegisterApp_StoresAppInfo() public {

--- a/docs/DEPLOY_RUNBOOK.md
+++ b/docs/DEPLOY_RUNBOOK.md
@@ -17,6 +17,10 @@
 | 1 | 配 tapp-server config 的 owner，起 tapp 服务器 | 该 owner key 之后用于所有 start/stop/register | ✅ | ✅ |
 | 2 | `start-app` 起服务 | `PROVIDER_ADDRESS` 必须 == 该 app 的链上 owner；先 `docker-login` 私有 registry；`.env` 的 `TAPP_REGISTRY`/`SETTLEMENT_CONTRACT` 要齐 | ✅ | ✅ |
 | 3 | `register-onchain` 注册上链 | 各质押 1 0G | ✅ | ✅ |
+
+> 步骤 2+3 可合并为一条：`start-app --register-onchain --rpc-url … --contract … --stake-wei …`
+> 会在容器启动**之前**幂等注册（未注册→registerApp；已注册但本节点 signer 不在 node list→addNode；已在→跳过）。
+> server 先 pull 镜像算好 hash，交易确认后才 up；重启后 signer 变的场景会自动走 addNode（旧 node 仍需手动 remove/update）。
 | 4 | `authorizeInvalidator(appId, <SandboxServing 合约地址>)` | 授权兄弟合约 SandboxServing 调 `invalidateAcks`，使改价能作废用户 ack；**必须在第 5 步前** | ✅ | — |
 | 5 | `cmd/provider register` 绑服务到 SandboxServing | 设 `services[provider].appId` + 价格 | ✅ | — |
 
@@ -28,6 +32,11 @@ tapp-cli -s http://<server>:50051 -k 0x<owner-key> start-app -f <compose> --app-
 # 3. 注册上链（key 必须既是 server owner 又是有钱的 app owner）
 tapp-cli -s http://<server>:50051 -k 0x<owner-key> register-onchain \
   --app-id <appId> --rpc-url https://evmrpc-testnet.0g.ai \
+  --contract 0x95a0BF4148b30F6F8D86870534c51df46Da5511c --stake-wei 1000000000000000000
+
+# 2+3 合并版：先注册再起（幂等，可反复跑）
+tapp-cli -s http://<server>:50051 -k 0x<owner-key> start-app -f <compose> --app-id <appId> \
+  --register-onchain --rpc-url https://evmrpc-testnet.0g.ai \
   --contract 0x95a0BF4148b30F6F8D86870534c51df46Da5511c --stake-wei 1000000000000000000
 
 # 4. 授权 invalidator（注意：授权的是 SandboxServing 合约地址，不是 owner 钱包）

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -3,7 +3,8 @@
 [logging]
 level = "info"  # Log level: "trace", "debug", "info", "warn", "error"
 format = "json" # Log format: "json" or "pretty"
-# file_path = "/var/log/tapp/app.log"  # Optional: log to file
+# file_path = "/var/log/tapp/app.log"  # Optional: log to file (daily rotation)
+# max_log_files = 7  # Rotated daily files to keep; oldest deleted (default: 7)
 
 [server]
 bind_address = "0.0.0.0:50051"

--- a/gcp-cvm/README.md
+++ b/gcp-cvm/README.md
@@ -6,15 +6,23 @@ Build a bootable, measurable, remotely-attestable, security-hardened cryptpilot 
 | File | Description |
 |---|---|
 | `cryptpilot-gcp-boot-fix.md` | **Main doc**: root-cause analysis + fixes + full SOP (§9) + security-hardening audit (§11) + convert issues for Alibaba Cloud (§7) |
-| `build-gcp-tapp.sh` | **One-shot full chain**: bare image → final gcp-tapp (stage A installs app/docker/SGX/DNS + hardening / stage B kernel + convert + ESP) |
+| `build-gcp-tapp.sh` | **One-shot full chain**: base image → final gcp-tapp (Stage A app/docker/SGX/DNS + hardening + /data + Sysbox / Stage B kernel + convert + ESP / opt-in Stage C publish via `PUBLISH_AS=`) |
 | `prepare-gcp-tapp.sh` | Stage B only (when a base already exists): fix A + DNS (guestfish) + nbd reset + convert + fix B |
+| `publish-gcp-image.sh` | **Stage C**: publish a built qcow2 to GCP — `qemu-img` raw → oldgnu sparse `tar.gz` → `gsutil` → `gcloud compute images create` (confidential guest-os-features). Needs gcloud/gsutil auth |
 | `fix-esp-grub.sh` | Sync the ESP grub only (fix B, can be run standalone against an already-converted image) |
 | `test/boot-smoke-test.sh` | **Local boot smoke test**: boots a converted image under QEMU/OVMF (no real GCP CVM needed) and checks the boot chain reaches multi-user / tapp-server |
 | `config_dir/` | cryptpilot convert config (`fde.toml`, `rw_overlay="ram"`) |
 | `cryptpilot-fde_0.7.0_amd64.deb` | FDE **runtime installed into the target image**. **Binary, gitignored**, must be placed locally in this directory (see Prerequisites) |
 
-> The artifact `gcp-tapp.qcow2` (~6G, converted / verity-sealed / hardened) is the **output** of `build-gcp-tapp.sh` and is not committed (gitignored).
+> The artifact `gcp-tapp.qcow2` (~4.5G, converted / verity-sealed / hardened) is the **output** of `build-gcp-tapp.sh` and is not committed (gitignored).
 > The same applies to `cryptpilot-fde_*.deb` and the tapp-server binary: the deb must be placed locally in this directory; tapp-server is pulled by default from GitHub release v0.1.0 (see below).
+
+## Pipeline (stages)
+- **Stage 0 — base prep** *(one-time, reused across builds)*: official Ubuntu 24.04 cloud image → resize to 20 GiB + gVNIC driver → base qcow2. See `cryptpilot-gcp-boot-fix.md` §0. This is the input to Stage A, not part of `build-gcp-tapp.sh`.
+- **Stage A** (`build-gcp-tapp.sh`): provision app / docker / SGX / DNS, security hardening, Sysbox, and the `/data` + `br_netfilter` bakes.
+- **Stage B** (`prepare-gcp-tapp.sh`, invoked by A): install the gcp kernel → fix A → `cryptpilot-convert` → sync ESP (fix B).
+- *(optional)* local boot smoke test (`test/boot-smoke-test.sh`).
+- **Stage C** (`publish-gcp-image.sh`): raw → sparse `tar.gz` → GCS → `gcloud compute images create`. Run standalone, or from `build-gcp-tapp.sh` via `PUBLISH_AS=<name>`.
 
 ## Prerequisites
 - **Conversion host = Anolis / Alibaba Cloud Linux 3 (al8).** `cryptpilot-convert` is only packaged for al8; a plain Ubuntu/macOS host cannot run it.
@@ -46,6 +54,7 @@ KBS_URLS='"http://<kbs-host-1>:9091", "http://<kbs-host-2>:9091"' \
   - `KBS_URLS` — KBS node URLs for `[kbs] node_urls`, comma-separated and quoted as shown.
 - tapp-server is downloaded by default from GitHub v0.1.0 (includes the guest-components `8d71a3b4` fix, RTMR OK); if you have it locally, set `TAPP_SERVER_BIN=<path>`.
 - Storage / Sysbox knobs: `DATA_ROOT` (docker data-root, default `/data/docker`), `CONTAINERD_ROOT` (default `/data/containerd`), `DOCKER_VERSION` (default `5:27.5.1-…noble`; empty = repo default), `ENABLE_SYSBOX` / `SYSBOX_VERSION` (default `0.7.0`).
+- Publish (Stage C, opt-in): `PUBLISH_AS=<gcp-image-name>` publishes the built image to GCP after the build (see [Publish to GCP](#publish-to-gcp-stage-c)); `GCS_BUCKET` / `GCP_PROJECT` / `GUEST_OS_FEATURES` pass through.
 - Other environment variables: `DNS_FALLBACK` `PURGE_KERNEL` `CONFIG_DIR` `FDE_PACKAGE` `ROOTFS_MODE` `IN_PLACE` `INSTALL_KERNEL` `NBD_RESET` (see the top of the script).
 
 ## Persistent data disk (`/data`) — always configured
@@ -85,6 +94,20 @@ Before uploading an image to GCP, sanity-check that it actually boots, locally, 
 It boots the image under QEMU/OVMF (UEFI) in the `qemux/qemu` container — using `/dev/kvm` if present, otherwise TCG software emulation — and scans the serial console for the full chain: grub → gcp kernel → `cryptpilot-fde` (dm-verity + zram + dm-snapshot) → `/sysroot` mount → switch-root → multi-user / `tapp-server.service`. Exit code `0` means the boot was confirmed.
 
 This validates everything except the TDX-specific bits (RTMR extend, remote attestation), which require real hardware — so it is a fast pre-flight check, not a replacement for on-hardware testing. Tunables: `MAX` (timeout seconds), `RAM_SIZE`, `CPU_CORES`.
+
+<a name="publish-to-gcp-stage-c"></a>
+## Publish to GCP (Stage C)
+A qcow2 can't be uploaded to GCP directly — it must become a `disk.raw` inside a sparse `oldgnu` tarball, then a GCP image. `publish-gcp-image.sh` does the four steps (`qemu-img convert` → `tar --format=oldgnu -Szcf` → `gsutil cp` → `gcloud compute images create` with `UEFI_COMPATIBLE,GVNIC,SEV_CAPABLE,TDX_CAPABLE`):
+```bash
+gcloud auth login            # gcloud + gsutil must be authenticated with write access to the bucket/project
+./publish-gcp-image.sh /path/og-tdx-dev.qcow2 og-tdx-dev
+./publish-gcp-image.sh /path/og-tdx.qcow2     og-tdx
+```
+Defaults `GCS_BUCKET=gs://tapp-image`, `GCP_PROJECT=g-devops`, `GUEST_OS_FEATURES=UEFI_COMPATIBLE,GVNIC,SEV_CAPABLE,TDX_CAPABLE` (all overridable). It refuses to clobber an existing image name (delete it, or publish under a new name). Or fold it into the build as an opt-in final stage:
+```bash
+PUBLISH_AS=og-tdx-dev ENABLE_SYSBOX=1 OWNER_ADDRESS=0x... KBS_URLS='...' ./build-gcp-tapp.sh base.qcow2 og-tdx-dev.qcow2
+```
+Create a confidential instance from the published image with `--image=<name> --image-project=g-devops --confidential-compute-type=TDX`.
 
 ## Three core fixes (all required)
 - **Fix A**: before convert, point the `/boot/vmlinuz` symlink at the gcp kernel → the cryptpilot stack goes into the correct initrd (fixes read-only / RTMR / verity).

--- a/gcp-cvm/build-gcp-tapp.sh
+++ b/gcp-cvm/build-gcp-tapp.sh
@@ -80,6 +80,9 @@ cat > "$TMPD/tapp-server.service" <<'EOF'
 Description=TAPP gRPC Server - Trusted Application
 After=network.target
 Wants=network.target
+# File logs live on the persistent /data disk (RAM rootfs would grow unbounded,
+# issue #23) — same fail-loud policy as docker/containerd: no /data, no start.
+RequiresMountsFor=/data
 
 [Service]
 Type=simple
@@ -104,7 +107,10 @@ cat > "$TMPD/config.toml" <<EOF
 [logging]
 level = "info"
 format = "pretty"
-file_path = "/var/log/tapp/"
+# On the persistent /data disk, NOT the RAM rootfs (rw_overlay="ram") — file
+# logs on "/" consume RAM and are lost on reboot (issue #23). tapp-server keeps
+# at most `max_log_files` daily files (default 7).
+file_path = "/data/log/tapp/"
 
 [server.permission]
 enabled = true

--- a/gcp-cvm/build-gcp-tapp.sh
+++ b/gcp-cvm/build-gcp-tapp.sh
@@ -45,6 +45,10 @@ export FDE_PACKAGE="${FDE_PACKAGE:-$HERE/cryptpilot-fde_0.7.0_amd64.deb}"
 export ROOTFS_MODE="${ROOTFS_MODE:---rootfs-no-encryption}"
 export PURGE_KERNEL="${PURGE_KERNEL:-}"   # NOTE: convert needs at least one *-generic kernel left in the image; do not purge them all
 export INSTALL_KERNEL=1
+# Stage C (opt-in): if set, publish $OUT to GCP as this image name after the build (raw -> tar.gz ->
+# gsutil -> gcloud images create). Empty = build only. Needs gcloud/gsutil auth; see publish-gcp-image.sh
+# (GCS_BUCKET / GCP_PROJECT / GUEST_OS_FEATURES are passed through to it).
+PUBLISH_AS="${PUBLISH_AS:-}"
 # ====================
 
 IN="${1:?usage: $0 <ubuntu-24.04-base.qcow2> <output.qcow2>}"
@@ -225,7 +229,7 @@ PROVSH
 chmod 0755 /usr/local/sbin/tapp-data-provision.sh
 cat > /etc/systemd/system/tapp-data-provision.service <<'PROVUNIT'
 [Unit]
-Description=Auto-provision /data (carve from boot-disk free space if no tapp-data fs exists)
+Description=Auto-provision /data (format a blank data disk, or adopt an existing one, as tapp-data)
 After=systemd-udev-settle.service
 Wants=systemd-udev-settle.service
 Before=data.mount
@@ -381,3 +385,10 @@ IN_PLACE=1 "$HERE/prepare-gcp-tapp.sh" "$IN" "$OUT"
 echo ""
 echo "[done] final image: $OUT"
 echo "(note: $IN was modified in place; re-download the original base image if you need it again)"
+
+# ---- stage C (opt-in): publish $OUT to GCP as image $PUBLISH_AS ----
+if [ -n "$PUBLISH_AS" ]; then
+  [ -x "$HERE/publish-gcp-image.sh" ] || { echo "PUBLISH_AS set but publish-gcp-image.sh not found/executable in $HERE" >&2; exit 1; }
+  echo "==> [C] publish-gcp-image.sh: $OUT -> GCP image '$PUBLISH_AS'"
+  "$HERE/publish-gcp-image.sh" "$OUT" "$PUBLISH_AS"
+fi

--- a/gcp-cvm/cryptpilot-gcp-boot-fix.md
+++ b/gcp-cvm/cryptpilot-gcp-boot-fix.md
@@ -459,3 +459,31 @@ The rootfs writable overlay is `rw_overlay = "ram"` (zram) — **anything writte
 - **Sysbox data store** (`sysbox-mgr --data-root`, holds inner-container images) is also moved to `/data/sysbox` via a drop-in that preserves the vendor `ExecStart`.
 - **Kernel**: idmapped mounts (gcp kernel ≥5.12) are required; **6.17.0-*-gcp verified on hardware** (`docker run --runtime=sysbox-runc alpine cat /proc/self/uid_map` → `0 100000 65536`).
 - **`br_netfilter` must be loaded** (baked via `/etc/modules-load.d/`, unconditional). Docker 28's `icc=false` bridges — created by the 0g-sandbox runner (`INTER_SANDBOX_NETWORK_ENABLED=false`) — hard-require `/proc/sys/net/bridge/bridge-nf-call-iptables`, which exists only once `br_netfilter` is loaded. On a fresh CVM without it the runner crash-loops (`bridge-nf-call-iptables: no such file`); a node where it happened to be loaded worked, masking the gap.
+
+## 14. Stage C: publish the image to GCP
+
+A built qcow2 (§9 output) cannot be uploaded to GCP directly — GCP wants a raw disk named exactly `disk.raw` inside a **sparse `oldgnu`-format tarball**, imported as an image with the confidential guest-os-features. `gcp-cvm/publish-gcp-image.sh <image.qcow2> <gcp-image-name>` runs the four steps:
+
+```bash
+# [C1] qcow2 -> raw
+qemu-img convert -p -f qcow2 -O raw og-tdx.qcow2 disk.raw
+# [C2] raw -> sparse oldgnu tarball (member MUST be exactly "disk.raw")
+tar --format=oldgnu -Szcf og-tdx.tar.gz -C <dir> disk.raw
+# [C3] upload
+gsutil cp og-tdx.tar.gz gs://tapp-image/
+# [C4] create the GCP image (confidential features)
+gcloud compute images create og-tdx --project=g-devops \
+  --source-uri=gs://tapp-image/og-tdx.tar.gz \
+  --guest-os-features=UEFI_COMPATIBLE,GVNIC,SEV_CAPABLE,TDX_CAPABLE
+```
+
+Notes:
+- **Auth**: needs `gcloud auth login` and write access to the bucket/project. This is why Stage C is separate from the build (which needs no cloud creds) — run it after §9, or fold it in with `PUBLISH_AS=<name>` on `build-gcp-tapp.sh`.
+- **`--format=oldgnu -S`**: GCP's importer requires the GNU-old tar format; `-S` keeps the (mostly-empty) 20 GiB raw sparse so the tarball stays small (~few GB).
+- **`-C <dir> disk.raw`**: the archive member must be the bare name `disk.raw`, not a path.
+- **Guest-OS features**: `UEFI_COMPATIBLE` (cryptpilot boots via UEFI/ESP), `GVNIC` (network driver), `SEV_CAPABLE`+`TDX_CAPABLE` (usable as an AMD-SEV or Intel-TDX confidential VM).
+- The script refuses to overwrite an existing image name (delete it first, or publish a versioned name, e.g. `og-tdx-YYYYMMDD`).
+- Boot a confidential instance from it: `gcloud compute instances create … --image=og-tdx --image-project=g-devops --confidential-compute-type=TDX --maintenance-policy=TERMINATE`.
+
+### Stages at a glance
+**Stage 0** (§0, one-time base prep: official Ubuntu → resize 20 GiB + gVNIC) → **Stage A** (provision + harden + Sysbox + /data/br_netfilter) → **Stage B** (gcp kernel + convert + ESP) → *(optional local boot smoke test, README)* → **Stage C** (publish to GCP).

--- a/gcp-cvm/publish-gcp-image.sh
+++ b/gcp-cvm/publish-gcp-image.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# publish-gcp-image.sh <image.qcow2> <gcp-image-name>
+#
+# Stage C: turn a built cryptpilot tapp qcow2 into a bootable GCP image. Four steps:
+#   [C1] qemu-img convert qcow2 -> raw disk.raw
+#   [C2] tar (oldgnu, sparse) -> <name>.tar.gz   (GCP requires an archive whose single member is
+#        exactly "disk.raw")
+#   [C3] gsutil cp the tarball to the GCS bucket
+#   [C4] gcloud compute images create with the confidential-VM guest-os-features
+#
+# Requires: qemu-img, tar, gsutil, gcloud (authenticated: `gcloud auth login`), and write access to
+# the target GCS bucket / project. This step is separate from the image build because it needs cloud
+# credentials and network upload; run it after build-gcp-tapp.sh (or via that script's opt-in Stage C).
+#
+# Usage:
+#   ./publish-gcp-image.sh /root/og-tdx.qcow2 og-tdx
+#   GCS_BUCKET=gs://tapp-image GCP_PROJECT=g-devops ./publish-gcp-image.sh og-tdx-dev.qcow2 og-tdx-dev
+
+set -euo pipefail
+
+IMG="${1:?usage: $0 <image.qcow2> <gcp-image-name>}"
+NAME="${2:?usage: $0 <image.qcow2> <gcp-image-name>}"
+[ -f "$IMG" ] || { echo "image not found: $IMG" >&2; exit 1; }
+
+# ===== Tunables =====
+GCS_BUCKET="${GCS_BUCKET:-gs://tapp-image}"
+GCP_PROJECT="${GCP_PROJECT:-g-devops}"
+GUEST_OS_FEATURES="${GUEST_OS_FEATURES:-UEFI_COMPATIBLE,GVNIC,SEV_CAPABLE,TDX_CAPABLE}"
+WORKDIR="${WORKDIR:-$(cd "$(dirname "$IMG")" && pwd)}"   # where disk.raw / tarball are staged
+KEEP_TARBALL="${KEEP_TARBALL:-0}"                         # 1 = keep the local .tar.gz after upload
+# ====================
+
+for t in qemu-img tar gsutil gcloud; do command -v "$t" >/dev/null || { echo "missing tool: $t" >&2; exit 1; }; done
+
+RAW="$WORKDIR/disk.raw"
+TAR="$WORKDIR/$NAME.tar.gz"
+
+# refuse to clobber an existing image name (gcloud would error anyway; give a clearer hint up front)
+if gcloud compute images describe "$NAME" --project="$GCP_PROJECT" >/dev/null 2>&1; then
+  echo "GCP image '$NAME' already exists in project $GCP_PROJECT." >&2
+  echo "  delete it first:  gcloud compute images delete $NAME --project=$GCP_PROJECT" >&2
+  echo "  or publish under a new name (e.g. ${NAME}-$(date +%Y%m%d) — pass a different <gcp-image-name>)." >&2
+  exit 1
+fi
+
+cleanup() { rm -f "$RAW"; [ "$KEEP_TARBALL" = 1 ] || rm -f "$TAR"; }
+trap cleanup EXIT
+
+echo "==> [C1] qemu-img convert qcow2 -> raw ($RAW)"
+qemu-img convert -p -f qcow2 -O raw "$IMG" "$RAW"
+
+echo "==> [C2] tar (oldgnu, sparse) -> $TAR"
+# -C so the archive member is exactly "disk.raw" (GCP requirement), -S to keep the sparse raw small
+tar --format=oldgnu -Szcf "$TAR" -C "$WORKDIR" disk.raw
+
+echo "==> [C3] upload -> $GCS_BUCKET/"
+gsutil cp "$TAR" "$GCS_BUCKET/"
+
+echo "==> [C4] create GCP image '$NAME' (project $GCP_PROJECT, features $GUEST_OS_FEATURES)"
+gcloud compute images create "$NAME" \
+  --project="$GCP_PROJECT" \
+  --source-uri="$GCS_BUCKET/$(basename "$TAR")" \
+  --guest-os-features="$GUEST_OS_FEATURES"
+
+echo ""
+echo "[done] GCP image: $NAME  (project $GCP_PROJECT)"
+echo "  create an instance with:  --image=$NAME --image-project=$GCP_PROJECT --confidential-compute-type=TDX"

--- a/proto/tapp_service.proto
+++ b/proto/tapp_service.proto
@@ -607,6 +607,11 @@ message ContainerStatus {
 // GetSecretResource Messages
 message GetSecretResourceRequest {
   string app_id = 1;
+  // Optional hex-encoded derivation material, opaque to tapp — forwarded
+  // verbatim to KMS /app-key, which binds it into the derived key alongside
+  // app_id (e.g. AgenticID: chainId || contractAddress || sealId).
+  // Absent/empty derives purely from the app_id namespace, as before.
+  string material = 2;
 }
 
 message GetSecretResourceResponse {

--- a/proto/tapp_service.proto
+++ b/proto/tapp_service.proto
@@ -134,6 +134,11 @@ message StartAppRequest {
   string app_id = 2;  // Application identifier for key binding
   repeated MountFile mount_files =
       3;  // Files to mount (mapped by source_path from compose volumes)
+  // Pull images and compute measurements (compose/volumes/image hashes)
+  // WITHOUT starting containers. Used by the CLI to register the app
+  // on-chain before it actually runs; a follow-up StartApp (without this
+  // flag) then starts the containers from the cached images.
+  bool measure_only = 4;
 }
 
 message StartAppResponse {
@@ -163,6 +168,10 @@ message TaskResult {
   string app_id = 1;    // Application identifier (on success)
   string deployer = 2;  // Deployer EVM address (on success)
   string error = 3;     // Error message (on failure)
+  // Measurements, set only for measure_only tasks (see StartAppRequest).
+  string compose_hash = 4;                // Hash of compose file content
+  map<string, string> volumes_hash = 5;   // Map: file_name -> hash
+  map<string, string> image_hash = 6;     // Map: service_name -> image digest
 }
 
 message GetTaskStatusResponse {

--- a/src/boot/manager.rs
+++ b/src/boot/manager.rs
@@ -136,17 +136,13 @@ impl DockerComposeManager {
         Ok(source_to_host)
     }
 
-    /// Deploy Docker Compose application
-    pub async fn deploy_compose(
+    /// Store the compose file and mount files into the app directory.
+    /// Shared staging step for deploy_compose and pull_and_measure.
+    async fn stage_app_files(
         app_id: &str,
         compose_content: &str,
         mount_files: &[MountFile],
-    ) -> TappResult<std::collections::BTreeMap<String, String>> {
-        use std::sync::Arc;
-        use tokio::io::{AsyncBufReadExt, BufReader};
-        use tokio::sync::Mutex;
-
-        // 1. store compose file
+    ) -> TappResult<PathBuf> {
         let base_path = Self::get_app_dir(app_id);
         if !base_path.exists() {
             fs::create_dir_all(&base_path).await.map_err(|e| {
@@ -158,8 +154,99 @@ impl DockerComposeManager {
         let compose_path = base_path.join("docker-compose.yml");
         fs::write(&compose_path, compose_content).await?;
 
-        // 2. store mount files to corresponding location
         Self::store_mount_files(&base_path, mount_files).await?;
+        Ok(base_path)
+    }
+
+    /// Pull images and return their digests WITHOUT starting containers.
+    /// Stages the app files, runs `docker compose pull`, then resolves each
+    /// service's image digest. Used to register an app on-chain before it runs;
+    /// the follow-up deploy_compose starts containers from the cached images.
+    pub async fn pull_and_measure(
+        app_id: &str,
+        compose_content: &str,
+        mount_files: &[MountFile],
+    ) -> TappResult<std::collections::BTreeMap<String, String>> {
+        let base_path = Self::stage_app_files(app_id, compose_content, mount_files).await?;
+
+        info!(app_id = %app_id, "📥 Pulling images (measure-only, containers not started)");
+        let output = Command::new("docker")
+            .current_dir(&base_path)
+            .args(["compose", "-f", "docker-compose.yml", "pull"])
+            .output()
+            .await
+            .map_err(|e| DockerError::ContainerOperationFailed {
+                operation: "docker_compose_pull".to_string(),
+                reason: format!("Failed to execute docker compose pull: {}", e),
+            })?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            error!(app_id = %app_id, stderr = %stderr, "❌ Docker compose pull failed");
+            return Err(DockerError::ContainerOperationFailed {
+                operation: "docker_compose_pull".to_string(),
+                reason: format!(
+                    "Docker compose pull failed with exit code {:?}\nStderr: {}",
+                    output.status.code(),
+                    stderr
+                ),
+            }
+            .into());
+        }
+
+        // Resolve service -> image digest from the pulled (local) images
+        let mut image_map = std::collections::BTreeMap::new();
+        for (service, image) in Self::compose_service_images(compose_content)? {
+            let digest = Self::get_image_digest(&image).await.unwrap_or_else(|e| {
+                warn!(service = %service, image = %image, error = %e, "Failed to get image digest");
+                String::new()
+            });
+            image_map.insert(service, digest);
+        }
+
+        info!(
+            app_id = %app_id,
+            image_count = image_map.len(),
+            "📦 Measured image digests without starting containers"
+        );
+        Ok(image_map)
+    }
+
+    /// Parse service_name -> image reference from compose content.
+    /// Services without an `image` key (e.g. build-only) are skipped.
+    fn compose_service_images(compose_content: &str) -> TappResult<Vec<(String, String)>> {
+        let compose: serde_yaml::Value =
+            serde_yaml::from_str(compose_content).map_err(|e| TappError::InvalidParameter {
+                field: "compose_content".to_string(),
+                reason: format!("Failed to parse compose file: {}", e),
+            })?;
+
+        let mut result = Vec::new();
+        if let Some(services) = compose.get("services").and_then(|s| s.as_mapping()) {
+            for (name, service) in services {
+                if let (Some(name), Some(image)) = (
+                    name.as_str(),
+                    service.get("image").and_then(|i| i.as_str()),
+                ) {
+                    result.push((name.to_string(), image.to_string()));
+                }
+            }
+        }
+        Ok(result)
+    }
+
+    /// Deploy Docker Compose application
+    pub async fn deploy_compose(
+        app_id: &str,
+        compose_content: &str,
+        mount_files: &[MountFile],
+    ) -> TappResult<std::collections::BTreeMap<String, String>> {
+        use std::sync::Arc;
+        use tokio::io::{AsyncBufReadExt, BufReader};
+        use tokio::sync::Mutex;
+
+        // 1-2. store compose file and mount files
+        let base_path = Self::stage_app_files(app_id, compose_content, mount_files).await?;
 
         // 3. start compose with real-time output
         info!(app_id = %app_id, "🚀 Starting docker compose up");

--- a/src/boot/manager.rs
+++ b/src/boot/manager.rs
@@ -617,45 +617,6 @@ impl DockerComposeManager {
         Ok(())
     }
 
-    /// Check if a service is running
-    pub async fn is_service_running(app_id: &str, service_name: &str) -> TappResult<bool> {
-        let app_dir = Self::get_app_dir(app_id);
-
-        if !app_dir.exists() {
-            return Ok(false);
-        }
-
-        // Execute: docker compose ps --services --filter "status=running" --format json
-        let output = tokio::process::Command::new("docker")
-            .args(&[
-                "compose",
-                "ps",
-                "--services",
-                "--filter",
-                "status=running",
-                "--format",
-                "json",
-            ])
-            .current_dir(&app_dir)
-            .output()
-            .await
-            .map_err(|e| {
-                TappError::Docker(DockerError::ContainerOperationFailed {
-                    operation: "check_service_status".to_string(),
-                    reason: format!("Failed to execute docker compose ps: {}", e),
-                })
-            })?;
-
-        if !output.status.success() {
-            // If command fails, assume service is not running
-            return Ok(false);
-        }
-
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        // Check if service_name appears in the output
-        Ok(stdout.contains(service_name))
-    }
-
     /// Get image hash for a specific service
     pub async fn get_service_image(app_id: &str, service_name: &str) -> TappResult<Option<String>> {
         let image_map = Self::get_container_images(app_id).await?;
@@ -972,19 +933,11 @@ impl DockerComposeManager {
             });
         }
 
-        // Check if service is already running
-        let is_running = Self::is_service_running(app_id, service_name).await?;
-        if is_running {
-            warn!(
-                app_id = %app_id,
-                service_name = %service_name,
-                "Service is already running"
-            );
-            return Err(TappError::InvalidParameter {
-                field: "service_name".to_string(),
-                reason: format!("Service {} is already running", service_name),
-            });
-        }
+        // No "already running" pre-check: `docker compose up -d` is idempotent
+        // (running + unchanged config = no-op; with --pull always it recreates on a
+        // new image, and the caller re-measures). A pre-check would also have to
+        // match service names exactly — a substring check once broke restart when a
+        // sibling service shared the prefix, e.g. sandbox vs sandbox-redis (issue #27).
 
         info!(
             app_id = %app_id,

--- a/src/boot/mod.rs
+++ b/src/boot/mod.rs
@@ -144,6 +144,63 @@ enable_eventlog = true
             })
             .collect();
 
+        // Measure-only: pull images and compute hashes, but don't start containers.
+        // Result (compose/volumes/image hashes) is returned via the task result so
+        // the CLI can register the app on-chain before actually starting it.
+        if request.measure_only {
+            let image_hash = match DockerComposeManager::pull_and_measure(
+                &app_id,
+                &request.compose_content,
+                &mount_files,
+            )
+            .await
+            {
+                Ok(map) => map,
+                Err(e) => {
+                    self.task_manager
+                        .mark_failed(&task_id, format!("Failed to pull/measure images: {}", e))
+                        .await;
+                    return;
+                }
+            };
+
+            let measurement = match self
+                .calculate_app_measurement(
+                    &request,
+                    &mount_files,
+                    &app_id,
+                    &deployer,
+                    crate::measurement_service::OPERATION_NAME_START_APP,
+                    image_hash.clone(),
+                )
+                .await
+            {
+                Ok((m, _, _)) => m,
+                Err(e) => {
+                    self.task_manager
+                        .mark_failed(&task_id, format!("Failed to calculate measurement: {}", e))
+                        .await;
+                    return;
+                }
+            };
+
+            // Note: no extend_measurement and no AppInfo registration here — the
+            // app has not run; the follow-up real StartApp does both as usual.
+            self.task_manager
+                .mark_completed(
+                    &task_id,
+                    TaskSuccessResult {
+                        app_id,
+                        deployer,
+                        compose_hash: measurement.compose_hash,
+                        volumes_hash: measurement.volumes_hash,
+                        image_hash,
+                    },
+                )
+                .await;
+            return;
+        }
+
         // Try to start the application
         let deploy_result = async {
             info!(
@@ -279,7 +336,10 @@ enable_eventlog = true
 
                 // Mark task as completed
                 self.task_manager
-                    .mark_completed(&task_id, TaskSuccessResult { app_id, deployer })
+                    .mark_completed(
+                        &task_id,
+                        TaskSuccessResult { app_id, deployer, ..Default::default() },
+                    )
                     .await;
             }
             Err(e) => {
@@ -1039,6 +1099,7 @@ enable_eventlog = true
                         TaskSuccessResult {
                             app_id,
                             deployer: app_info.owner,
+                            ..Default::default()
                         },
                     )
                     .await;

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,6 +30,12 @@ pub struct LoggingConfig {
 
     /// Log file path (if None, logs to stdout)
     pub file_path: Option<PathBuf>,
+
+    /// Maximum number of rotated (daily) log files to keep; oldest are deleted.
+    /// Bounds total log growth — without a cap, daily rotation still grows
+    /// unbounded and can exhaust the RAM rootfs on CVM images (issue #23).
+    #[serde(default = "default_max_log_files")]
+    pub max_log_files: usize,
 }
 
 /// Main configuration structure for TAPP service
@@ -218,6 +224,10 @@ fn default_log_format() -> String {
     "json".to_string()
 }
 
+fn default_max_log_files() -> usize {
+    7
+}
+
 impl Default for KbsConfig {
     fn default() -> Self {
         Self {
@@ -268,6 +278,7 @@ impl Default for LoggingConfig {
             level: default_log_level(),
             format: default_log_format(),
             file_path: None,
+            max_log_files: default_max_log_files(),
         }
     }
 }

--- a/src/kms_client.rs
+++ b/src/kms_client.rs
@@ -19,7 +19,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let client = KmsClient::new(vec![server.uri()]);
+        let client = KmsClient::new(vec![server.uri()], &Default::default());
         let result = client
             .get_encrypted_secret("myapp", 1234567890, "pubkey_hex", "sig_hex")
             .await
@@ -49,7 +49,7 @@ mod tests {
             .mount(&good_server)
             .await;
 
-        let client = KmsClient::new(vec![bad_server.uri(), good_server.uri()]);
+        let client = KmsClient::new(vec![bad_server.uri(), good_server.uri()], &Default::default());
         let result = client
             .get_encrypted_secret("myapp", 1234567890, "pubkey_hex", "sig_hex")
             .await
@@ -67,7 +67,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let client = KmsClient::new(vec![server.uri()]);
+        let client = KmsClient::new(vec![server.uri()], &Default::default());
         let result = client
             .get_encrypted_secret("myapp", 1234567890, "pubkey_hex", "sig_hex")
             .await;
@@ -77,7 +77,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_no_nodes_configured() {
-        let client = KmsClient::new(vec![]);
+        let client = KmsClient::new(vec![], &Default::default());
         let result = client
             .get_encrypted_secret("myapp", 1234567890, "pubkey_hex", "sig_hex")
             .await;

--- a/src/kms_client.rs
+++ b/src/kms_client.rs
@@ -21,11 +21,45 @@ mod tests {
 
         let client = KmsClient::new(vec![server.uri()], &Default::default());
         let result = client
-            .get_encrypted_secret("myapp", 1234567890, "pubkey_hex", "sig_hex")
+            .get_encrypted_secret("myapp", 1234567890, "pubkey_hex", "sig_hex", "")
             .await
             .unwrap();
 
         assert_eq!(result, vec![0xde, 0xad, 0xbe, 0xef]);
+    }
+
+    #[tokio::test]
+    async fn test_material_forwarded_and_empty_omitted() {
+        use wiremock::matchers::body_partial_json;
+
+        // Server only matches when the body carries the material field verbatim
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/app-key"))
+            .and(body_partial_json(
+                serde_json::json!({ "material": "deadbeef01" }),
+            ))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "encrypted_secret": "0xcafe" })),
+            )
+            .mount(&server)
+            .await;
+
+        let client = KmsClient::new(vec![server.uri()], &Default::default());
+
+        // material passed through verbatim -> matches
+        let result = client
+            .get_encrypted_secret("myapp", 1234567890, "pubkey_hex", "sig_hex", "deadbeef01")
+            .await
+            .unwrap();
+        assert_eq!(result, vec![0xca, 0xfe]);
+
+        // empty material -> field omitted from the JSON body -> no match -> error
+        let result = client
+            .get_encrypted_secret("myapp", 1234567890, "pubkey_hex", "sig_hex", "")
+            .await;
+        assert!(result.is_err());
     }
 
     #[tokio::test]
@@ -51,7 +85,7 @@ mod tests {
 
         let client = KmsClient::new(vec![bad_server.uri(), good_server.uri()], &Default::default());
         let result = client
-            .get_encrypted_secret("myapp", 1234567890, "pubkey_hex", "sig_hex")
+            .get_encrypted_secret("myapp", 1234567890, "pubkey_hex", "sig_hex", "")
             .await
             .unwrap();
 
@@ -69,7 +103,7 @@ mod tests {
 
         let client = KmsClient::new(vec![server.uri()], &Default::default());
         let result = client
-            .get_encrypted_secret("myapp", 1234567890, "pubkey_hex", "sig_hex")
+            .get_encrypted_secret("myapp", 1234567890, "pubkey_hex", "sig_hex", "")
             .await;
 
         assert!(result.is_err());
@@ -79,7 +113,7 @@ mod tests {
     async fn test_no_nodes_configured() {
         let client = KmsClient::new(vec![], &Default::default());
         let result = client
-            .get_encrypted_secret("myapp", 1234567890, "pubkey_hex", "sig_hex")
+            .get_encrypted_secret("myapp", 1234567890, "pubkey_hex", "sig_hex", "")
             .await;
 
         assert!(result.is_err());
@@ -96,6 +130,12 @@ struct KmsRequest<'a> {
     pubkey: String,
     /// hex-encoded secp256k1 signature over "GetSecretResource:{timestamp}"
     signature: String,
+    /// optional hex-encoded derivation material, opaque — forwarded verbatim to
+    /// KMS /app-key which binds it into the derived key alongside app_id.
+    /// Omitted from the JSON body when empty so the request is byte-identical
+    /// to the pre-material format (KMS then derives purely from app_id).
+    #[serde(skip_serializing_if = "str::is_empty")]
+    material: &'a str,
 }
 
 #[derive(Deserialize)]
@@ -130,12 +170,14 @@ impl KmsClient {
         timestamp: i64,
         pubkey_hex: &str,
         signature_hex: &str,
+        material: &str,
     ) -> Result<Vec<u8>> {
         let req = KmsRequest {
             app_id,
             timestamp,
             pubkey: pubkey_hex.to_string(),
             signature: signature_hex.to_string(),
+            material,
         };
 
         let mut last_err = anyhow!("no KMS nodes configured");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1483,9 +1483,11 @@ impl TappService for TappServiceImpl {
             .map_err(|e| Status::internal(format!("Failed to sign KMS request: {}", e)))?;
         let signature_hex = hex::encode(&signature);
 
-        // Call KMS cluster → get ECIES-encrypted app key
+        // Call KMS cluster → get ECIES-encrypted app key. `material` is opaque
+        // derivation material forwarded verbatim (empty = omitted, derives
+        // purely from the app_id namespace as before) — see issue #33.
         let encrypted = kms
-            .get_encrypted_secret(app_id, timestamp, &pubkey_hex, &signature_hex)
+            .get_encrypted_secret(app_id, timestamp, &pubkey_hex, &signature_hex, &req.material)
             .await
             .map_err(|e| Status::unavailable(format!("KMS request failed: {}", e)))?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1504,6 +1504,29 @@ impl TappService for TappServiceImpl {
 }
 
 /// Initialize tracing based on configuration
+/// Delete the oldest `{prefix}.*` daily log files so at most `max_files - 1`
+/// remain (the appender then creates/opens today's file, bringing the total
+/// back to `max_files`). Filenames embed the date (`prefix.yyyy-MM-dd`), so
+/// lexicographic order == chronological order. Best-effort: IO errors are
+/// ignored — logging setup must not fail because a stale file can't be removed.
+fn prune_old_log_files(directory: &std::path::Path, prefix: &str, max_files: usize) {
+    let Ok(entries) = std::fs::read_dir(directory) else {
+        return;
+    };
+    let wanted = format!("{}.", prefix);
+    let mut files: Vec<String> = entries
+        .filter_map(|e| e.ok()?.file_name().into_string().ok())
+        .filter(|name| name.starts_with(&wanted))
+        .collect();
+    if files.len() < max_files {
+        return;
+    }
+    files.sort();
+    for name in &files[..files.len() - (max_files - 1)] {
+        let _ = std::fs::remove_file(directory.join(name));
+    }
+}
+
 pub fn init_tracing(config: &config::LoggingConfig) -> TappResult<()> {
     use tracing_subscriber::{
         fmt::{self, format::FmtSpan},
@@ -1562,7 +1585,25 @@ pub fn init_tracing(config: &config::LoggingConfig) -> TappResult<()> {
             reason: format!("Cannot create log directory: {}", e),
         })?;
 
-        let file_appender = RollingFileAppender::new(Rotation::DAILY, directory, file_name_prefix);
+        // Keep at most `max_log_files` daily files — without a retention cap the
+        // rotated files accumulate forever, which on RAM-rootfs CVM images means
+        // unbounded RAM growth (issue #23).
+        //
+        // tracing-appender only prunes inside refresh_writer, i.e. when the date
+        // rolls over WHILE the process is running — files left by previous runs
+        // survive until the first in-process midnight, and a process that never
+        // lives past midnight never prunes at all. Prune at startup ourselves.
+        prune_old_log_files(directory, file_name_prefix, config.max_log_files.max(1));
+
+        let file_appender = RollingFileAppender::builder()
+            .rotation(Rotation::DAILY)
+            .filename_prefix(file_name_prefix)
+            .max_log_files(config.max_log_files.max(1))
+            .build(directory)
+            .map_err(|e| error::ConfigError::InvalidValue {
+                field: "logging.file_path".to_string(),
+                reason: format!("Cannot create log appender: {}", e),
+            })?;
 
         let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
         std::mem::forget(_guard);
@@ -1599,6 +1640,44 @@ pub fn init_tracing(config: &config::LoggingConfig) -> TappResult<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_prune_old_log_files() {
+        let dir = std::env::temp_dir().join(format!("tapp-prune-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        // 10 accumulated daily files + an unrelated file that must survive
+        for d in 1..=10 {
+            std::fs::write(dir.join(format!("app.2026-07-{:02}", d)), "old").unwrap();
+        }
+        std::fs::write(dir.join("other.txt"), "keep").unwrap();
+
+        prune_old_log_files(&dir, "app", 7);
+
+        let mut files: Vec<String> = std::fs::read_dir(&dir)
+            .unwrap()
+            .map(|e| e.unwrap().file_name().into_string().unwrap())
+            .collect();
+        files.sort();
+        // newest 6 kept (appender's new file for today makes 7), oldest 4 gone
+        assert_eq!(
+            files,
+            vec![
+                "app.2026-07-05",
+                "app.2026-07-06",
+                "app.2026-07-07",
+                "app.2026-07-08",
+                "app.2026-07-09",
+                "app.2026-07-10",
+                "other.txt"
+            ]
+        );
+
+        // fewer files than the cap -> untouched
+        prune_old_log_files(&dir, "app", 7);
+        assert_eq!(std::fs::read_dir(&dir).unwrap().count(), 7);
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
 
     #[test]
     fn test_validate_app_id() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -362,13 +362,20 @@ impl TappService for TappServiceImpl {
         //     &req.key_type
         // };
 
-        let response = self.app_key_service.get_public_key(&req.app_id).await?;
+        // Create-if-missing (same as GetEvidence): allows fetching the signer
+        // address BEFORE the app starts, e.g. for on-chain pre-registration.
+        // The key lives in this process's memory, so the app gets the same key
+        // when it actually starts.
+        let key_pair = self
+            .app_key_service
+            .get_app_key(&req.app_id, "ethereum", req.x25519)
+            .await?;
         Ok(Response::new(GetAppKeyResponse {
             success: true,
             message: format!("Public key for app {}", req.app_id),
-            eth_address: response.0,
-            public_key: response.1,
-            x25519_public_key: response.2.unwrap_or_default(),
+            eth_address: key_pair.eth_address,
+            public_key: key_pair.public_key,
+            x25519_public_key: key_pair.x25519_public_key.unwrap_or_default(),
             key_source: "in-memory".to_string(),
         }))
     }

--- a/src/task_manager.rs
+++ b/src/task_manager.rs
@@ -12,10 +12,14 @@ pub enum TaskStatus {
     Failed(String),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct TaskSuccessResult {
     pub app_id: String,
     pub deployer: String, // EVM address from signature authentication
+    // Measurements, populated only by measure-only StartApp tasks
+    pub compose_hash: String,
+    pub volumes_hash: std::collections::BTreeMap<String, String>, // file_name -> hash
+    pub image_hash: std::collections::BTreeMap<String, String>,   // service_name -> digest
 }
 
 #[derive(Debug, Clone)]
@@ -52,11 +56,17 @@ impl Task {
                 app_id: result.app_id.clone(),
                 deployer: result.deployer.clone(),
                 error: String::new(),
+                compose_hash: result.compose_hash.clone(),
+                volumes_hash: result.volumes_hash.clone().into_iter().collect(),
+                image_hash: result.image_hash.clone().into_iter().collect(),
             }),
             TaskStatus::Failed(error) => Some(TaskResult {
                 app_id: String::new(),
                 deployer: String::new(),
                 error: error.clone(),
+                compose_hash: String::new(),
+                volumes_hash: Default::default(),
+                image_hash: Default::default(),
             }),
             _ => None,
         }

--- a/tapp-cli/Cargo.toml
+++ b/tapp-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tapp-cli"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 description = "Standalone CLI for TAPP gRPC server and on-chain operations"
 license.workspace = true

--- a/tapp-cli/Cargo.toml
+++ b/tapp-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tapp-cli"
-version = "0.1.1"
+version = "0.2.0"
 edition.workspace = true
 description = "Standalone CLI for TAPP gRPC server and on-chain operations"
 license.workspace = true

--- a/tapp-cli/build.rs
+++ b/tapp-cli/build.rs
@@ -1,0 +1,46 @@
+//! Stamp the gRPC interface version this CLI is built against into the binary.
+//!
+//! The gRPC interface version is the tapp-server `MAJOR.MINOR` (see
+//! `docs/VERSIONING.md`). tapp-cli and tapp-server live in the same workspace,
+//! so we read the server's version straight from the workspace root
+//! `Cargo.toml` at build time — no separate number to maintain. It is exposed
+//! as the `TAPP_EXPECTED_SERVER_VERSION` compile-time env var.
+
+use std::path::Path;
+
+fn main() {
+    let root_manifest = Path::new(env!("CARGO_MANIFEST_DIR")).join("../Cargo.toml");
+    println!("cargo:rerun-if-changed={}", root_manifest.display());
+
+    let text = std::fs::read_to_string(&root_manifest)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", root_manifest.display()));
+
+    let version = package_version(&text).unwrap_or_else(|| {
+        panic!(
+            "could not find [package] version in {}",
+            root_manifest.display()
+        )
+    });
+
+    println!("cargo:rustc-env=TAPP_EXPECTED_SERVER_VERSION={version}");
+}
+
+/// Extract the `version` value from the `[package]` table of a Cargo manifest,
+/// ignoring the `[workspace.package]` table that precedes it.
+fn package_version(manifest: &str) -> Option<String> {
+    let mut in_package = false;
+    for line in manifest.lines() {
+        let line = line.trim();
+        if line.starts_with('[') {
+            in_package = line == "[package]";
+            continue;
+        }
+        if in_package {
+            if let Some(rest) = line.strip_prefix("version") {
+                let value = rest.trim_start().strip_prefix('=')?.trim();
+                return Some(value.trim_matches('"').to_string());
+            }
+        }
+    }
+    None
+}

--- a/tapp-cli/src/main.rs
+++ b/tapp-cli/src/main.rs
@@ -31,7 +31,7 @@ async fn create_client(
         None
     };
 
-    if let Some(path) = unix_path {
+    let client = if let Some(path) = unix_path {
         let channel = tonic::transport::Endpoint::from_static("http://[::]:50051")
             .connect_with_connector(service_fn(move |_: http::Uri| {
                 let path = path.clone();
@@ -41,9 +41,36 @@ async fn create_client(
                 }
             }))
             .await?;
-        Ok(TappServiceClient::new(channel))
+        TappServiceClient::new(channel)
     } else {
-        Ok(TappServiceClient::connect(server.to_string()).await?)
+        TappServiceClient::connect(server.to_string()).await?
+    };
+
+    // Best-effort interface-version check: warn (never fail) if the server's
+    // gRPC interface looks incompatible with what this CLI was built for.
+    warn_if_incompatible(client.clone()).await;
+
+    Ok(client)
+}
+
+/// gRPC interface version this CLI was built against — the tapp-server
+/// `MAJOR.MINOR` (see `docs/VERSIONING.md`), stamped by `build.rs` from the
+/// workspace root `Cargo.toml`.
+const EXPECTED_SERVER_VERSION: &str = env!("TAPP_EXPECTED_SERVER_VERSION");
+
+/// Read the server version via `GetTappInfo` (a public RPC) and print a warning
+/// to stderr if its interface `MAJOR.MINOR` looks incompatible with this CLI.
+/// Any failure is ignored — the invoked command surfaces real connection errors.
+async fn warn_if_incompatible(mut client: TappServiceClient<tonic::transport::Channel>) {
+    if let Ok(resp) = client
+        .get_tapp_info(Request::new(GetTappInfoRequest {}))
+        .await
+    {
+        if let Some(warning) =
+            tapp_common::compat::interface_warning(&resp.get_ref().version, EXPECTED_SERVER_VERSION)
+        {
+            eprintln!("⚠️  {warning}");
+        }
     }
 }
 

--- a/tapp-cli/src/main.rs
+++ b/tapp-cli/src/main.rs
@@ -105,6 +105,26 @@ enum Commands {
         /// Application ID
         #[arg(short, long)]
         app_id: String,
+
+        /// Idempotently ensure the app is registered on-chain BEFORE it starts:
+        /// not registered -> registerApp; registered but this node's signer is
+        /// not in the node list -> addNode; signer already a node -> skip.
+        /// Images are pulled and measured first; containers only start after
+        /// the transaction is confirmed.
+        #[arg(long, requires_all = ["rpc_url", "contract", "stake_wei"])]
+        register_onchain: bool,
+
+        /// Ethereum RPC URL (with --register-onchain)
+        #[arg(long)]
+        rpc_url: Option<String>,
+
+        /// TappRegistry contract address 0x... (with --register-onchain)
+        #[arg(long)]
+        contract: Option<String>,
+
+        /// Stake in wei for registerApp/addNode, >= minStakeAmount (with --register-onchain)
+        #[arg(long)]
+        stake_wei: Option<u128>,
     },
 
     /// Stop a running application
@@ -544,8 +564,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Commands::StartApp {
             compose_file,
             app_id,
+            register_onchain,
+            rpc_url,
+            contract,
+            stake_wei,
         } => {
             let private_key = require_private_key(&cli.private_key)?;
+            if register_onchain {
+                // requires_all guarantees these are present
+                ensure_registered_onchain(
+                    &cli.server,
+                    &compose_file,
+                    &app_id,
+                    rpc_url.unwrap(),
+                    contract.unwrap(),
+                    stake_wei.unwrap(),
+                    &private_key,
+                )
+                .await?;
+            }
             start_app(&cli.server, compose_file, app_id, private_key).await?;
         }
         Commands::StopApp { app_id } => {
@@ -911,48 +948,210 @@ fn extract_volume_mounts(
     Ok(mount_files)
 }
 
+/// Send a StartApp request (optionally measure-only) and return the task id.
+async fn send_start_app(
+    server: &str,
+    compose_file: &PathBuf,
+    app_id: &str,
+    private_key: &str,
+    measure_only: bool,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let mut client = create_client(server).await?;
+
+    // Read compose file
+    let compose_content = std::fs::read_to_string(compose_file)?;
+
+    // Auto-extract volume mounts from compose file
+    let mount_files = extract_volume_mounts(compose_file, &compose_content)?;
+
+    // Create authenticated request with signature
+    let mut request = Request::new(StartAppRequest {
+        compose_content,
+        app_id: app_id.to_owned(),
+        mount_files,
+        measure_only,
+    });
+
+    // Add signature metadata
+    add_signature_metadata(&mut request, private_key, "StartApp")?;
+
+    let response = client.start_app(request).await?;
+    let result = response.into_inner();
+    if !result.success {
+        return Err(format!("StartApp request failed: {}", result.message).into());
+    }
+    Ok(result.task_id)
+}
+
 async fn start_app(
     server: &str,
     compose_file: PathBuf,
     app_id: String,
     private_key: String,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let mut client = create_client(server).await?;
-
-    // Read compose file
-    let compose_content = std::fs::read_to_string(&compose_file)?;
-
-    // Auto-extract volume mounts from compose file
-    let mount_files = extract_volume_mounts(&compose_file, &compose_content)?;
-
-    // Create authenticated request with signature
-    let mut request = Request::new(StartAppRequest {
-        compose_content,
-        app_id: app_id.clone(),
-        mount_files,
-    });
-
-    // Add signature metadata
-    add_signature_metadata(&mut request, &private_key, "StartApp")?;
-
-    let response = client.start_app(request).await?;
-    let result = response.into_inner();
+    let task_id = send_start_app(server, &compose_file, &app_id, &private_key, false).await?;
 
     println!("✓ Application start requested");
     println!("  App ID: {}", app_id);
-    println!("  Task ID: {}", result.task_id);
-    println!("  Message: {}", result.message);
+    println!("  Task ID: {}", task_id);
 
     // Show command to check progress with server parameter if not using default
     let check_command = if server == "http://127.0.0.1:50051" {
-        format!("tapp-cli get-task-status --task-id {}", result.task_id)
+        format!("tapp-cli get-task-status --task-id {}", task_id)
     } else {
         format!(
             "tapp-cli --server {} get-task-status --task-id {}",
-            server, result.task_id
+            server, task_id
         )
     };
     println!("\nUse '{}' to check progress", check_command);
+
+    Ok(())
+}
+
+/// Poll a task until it completes (returning its result) or fails.
+async fn wait_for_task(
+    server: &str,
+    task_id: &str,
+    timeout_secs: u64,
+) -> Result<tapp_common::proto::TaskResult, Box<dyn std::error::Error>> {
+    let mut client = create_client(server).await?;
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
+
+    loop {
+        let resp = client
+            .get_task_status(Request::new(GetTaskStatusRequest {
+                task_id: task_id.to_owned(),
+            }))
+            .await?
+            .into_inner();
+        // Note: resp.success is true ONLY for completed tasks; pending/running
+        // also report success=false, so branch on status instead.
+        if resp.created_at == 0 {
+            return Err(format!("GetTaskStatus failed: {}", resp.message).into());
+        }
+        match resp.status {
+            2 => return Ok(resp.result.unwrap_or_default()), // Completed
+            3 => {
+                let error = resp.result.map(|r| r.error).unwrap_or_default();
+                return Err(format!("Task {} failed: {}", task_id, error).into());
+            }
+            _ => {
+                if std::time::Instant::now() > deadline {
+                    return Err(format!(
+                        "Timed out after {}s waiting for task {}",
+                        timeout_secs, task_id
+                    )
+                    .into());
+                }
+                tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+            }
+        }
+    }
+}
+
+/// Idempotently make sure the app is registered on-chain BEFORE it starts:
+/// - app not registered            -> measure + registerApp (this node = first node)
+/// - registered, signer not a node -> measure + addNode
+/// - signer already a node         -> no-op
+/// "Measure" = a measure_only StartApp: the server pulls images and computes
+/// compose/volumes/image hashes without starting containers.
+async fn ensure_registered_onchain(
+    server: &str,
+    compose_file: &PathBuf,
+    app_id: &str,
+    rpc_url: String,
+    contract: String,
+    stake_wei: u128,
+    private_key: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use ethers::signers::Signer;
+    use ethers::types::{Address, U256};
+    use tapp_common::onchain::{self, OnchainParams};
+
+    let signer = fetch_signer_address(server, app_id).await?;
+    let owner = onchain::get_app_owner(&rpc_url, &contract, app_id).await?;
+
+    let is_first_node = if owner == Address::zero() {
+        true
+    } else {
+        let key_bytes = hex::decode(private_key.trim_start_matches("0x"))
+            .map_err(|e| format!("Invalid private key: {}", e))?;
+        let wallet = ethers::signers::LocalWallet::from_bytes(&key_bytes)
+            .map_err(|e| format!("Invalid private key: {}", e))?;
+        if owner != wallet.address() {
+            return Err(format!(
+                "App {} is owned by 0x{:x} on-chain, but the provided key is 0x{:x}",
+                app_id,
+                owner,
+                wallet.address()
+            )
+            .into());
+        }
+        let nodes = onchain::get_node_list(&rpc_url, &contract, app_id).await?;
+        if nodes.contains(&signer) {
+            println!(
+                "✓ Already registered on-chain (signer 0x{:x} is in the node list), skipping",
+                signer
+            );
+            return Ok(());
+        }
+        false
+    };
+
+    // Measure without starting: pull images, compute hashes
+    println!("⏳ Measuring app before on-chain registration (pulling images)...");
+    let task_id = send_start_app(server, compose_file, app_id, private_key, true).await?;
+    let measured = wait_for_task(server, &task_id, 900).await?;
+
+    // An old server ignores measure_only (unknown proto field) and returns no
+    // measurements — registering empty hashes would be silently wrong.
+    if measured.compose_hash.is_empty() {
+        return Err(
+            "Server did not return measurements: it likely predates measure_only support. \
+             Upgrade tapp-server or register with the standalone register-onchain command."
+                .into(),
+        );
+    }
+
+    let compose_hash = onchain::hex_to_bytes(&measured.compose_hash)?;
+    let volumes_hash = onchain::combine_map_hashes(&measured.volumes_hash);
+    let image_hashes = onchain::map_to_bytes_array(&measured.image_hash);
+
+    let params = OnchainParams { rpc_url: rpc_url.clone(), contract: contract.clone(), private_key: private_key.to_owned() };
+    if is_first_node {
+        let tx = onchain::register_app(
+            &params,
+            app_id,
+            compose_hash,
+            volumes_hash,
+            image_hashes,
+            signer,
+            server, // recorded on-chain as the node's evidence URL
+            U256::from(stake_wei),
+        )
+        .await?;
+        println!("✓ App registered on-chain");
+        println!("  Signer Address: 0x{:x}", signer);
+        println!("  Tx Hash: 0x{:x}", tx);
+    } else {
+        // Store a per-node override only when it differs from the app-level default
+        let (compose_override, volumes_override) =
+            node_override_hashes(&rpc_url, &contract, app_id, compose_hash, volumes_hash).await?;
+        let tx = onchain::add_node(
+            &params,
+            app_id,
+            signer,
+            server,
+            compose_override,
+            volumes_override,
+            U256::from(stake_wei),
+        )
+        .await?;
+        println!("✓ Node added on-chain");
+        println!("  Signer Address: 0x{:x}", signer);
+        println!("  Tx Hash: 0x{:x}", tx);
+    }
 
     Ok(())
 }

--- a/tapp-common/proto/tapp_service.proto
+++ b/tapp-common/proto/tapp_service.proto
@@ -607,6 +607,11 @@ message ContainerStatus {
 // GetSecretResource Messages
 message GetSecretResourceRequest {
   string app_id = 1;
+  // Optional hex-encoded derivation material, opaque to tapp — forwarded
+  // verbatim to KMS /app-key, which binds it into the derived key alongside
+  // app_id (e.g. AgenticID: chainId || contractAddress || sealId).
+  // Absent/empty derives purely from the app_id namespace, as before.
+  string material = 2;
 }
 
 message GetSecretResourceResponse {

--- a/tapp-common/proto/tapp_service.proto
+++ b/tapp-common/proto/tapp_service.proto
@@ -134,6 +134,11 @@ message StartAppRequest {
   string app_id = 2;  // Application identifier for key binding
   repeated MountFile mount_files =
       3;  // Files to mount (mapped by source_path from compose volumes)
+  // Pull images and compute measurements (compose/volumes/image hashes)
+  // WITHOUT starting containers. Used by the CLI to register the app
+  // on-chain before it actually runs; a follow-up StartApp (without this
+  // flag) then starts the containers from the cached images.
+  bool measure_only = 4;
 }
 
 message StartAppResponse {
@@ -163,6 +168,10 @@ message TaskResult {
   string app_id = 1;    // Application identifier (on success)
   string deployer = 2;  // Deployer EVM address (on success)
   string error = 3;     // Error message (on failure)
+  // Measurements, set only for measure_only tasks (see StartAppRequest).
+  string compose_hash = 4;                // Hash of compose file content
+  map<string, string> volumes_hash = 5;   // Map: file_name -> hash
+  map<string, string> image_hash = 6;     // Map: service_name -> image digest
 }
 
 message GetTaskStatusResponse {

--- a/tapp-common/src/compat.rs
+++ b/tapp-common/src/compat.rs
@@ -1,0 +1,75 @@
+//! CLI ↔ server interface-version compatibility check.
+//!
+//! Compatibility is decided on the `MAJOR.MINOR` of the peer's reported version
+//! — `PATCH` never changes the interface, so it is ignored here. See
+//! `docs/VERSIONING.md` for the full policy.
+
+/// Parse the `MAJOR.MINOR` interface identity from a full `X.Y.Z` version
+/// string, ignoring the `PATCH` digit. Returns `None` if the string does not
+/// look like a version.
+fn major_minor(version: &str) -> Option<(u64, u64)> {
+    let mut parts = version.trim().trim_start_matches('v').split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+    Some((major, minor))
+}
+
+/// Compare a peer's reported full version against the interface version this
+/// build was compiled for. Returns a human-readable warning when they may be
+/// incompatible, or `None` when compatible.
+///
+/// Only `MAJOR.MINOR` is considered:
+/// - different `MAJOR` → likely incompatible (different interface major line);
+/// - same `MAJOR`, peer `MINOR` older than expected → newer commands may fail;
+/// - otherwise → compatible (peer is same or newer, additive changes are safe).
+///
+/// If either version cannot be parsed, returns `None` (no spurious warning).
+pub fn interface_warning(peer_version: &str, expected_version: &str) -> Option<String> {
+    let (peer_major, peer_minor) = major_minor(peer_version)?;
+    let (exp_major, exp_minor) = major_minor(expected_version)?;
+
+    if peer_major != exp_major {
+        Some(format!(
+            "server interface v{peer_major}.{peer_minor} is on a different major line than this CLI expects (v{exp_major}.{exp_minor}); they are likely incompatible"
+        ))
+    } else if peer_minor < exp_minor {
+        Some(format!(
+            "server interface v{peer_major}.{peer_minor} is older than this CLI expects (v{exp_major}.{exp_minor}); newer commands may fail"
+        ))
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::interface_warning;
+
+    #[test]
+    fn patch_is_ignored() {
+        assert!(interface_warning("0.2.7", "0.2.1").is_none());
+        assert!(interface_warning("0.2.0", "0.2.9").is_none());
+    }
+
+    #[test]
+    fn newer_server_is_ok() {
+        assert!(interface_warning("0.3.0", "0.2.0").is_none());
+    }
+
+    #[test]
+    fn older_server_minor_warns() {
+        assert!(interface_warning("0.1.0", "0.2.0").is_some());
+    }
+
+    #[test]
+    fn major_mismatch_warns() {
+        assert!(interface_warning("1.0.0", "0.2.0").is_some());
+        assert!(interface_warning("0.9.9", "1.0.0").is_some());
+    }
+
+    #[test]
+    fn unparseable_is_silent() {
+        assert!(interface_warning("", "0.1.0").is_none());
+        assert!(interface_warning("dev", "0.1.0").is_none());
+    }
+}

--- a/tapp-common/src/lib.rs
+++ b/tapp-common/src/lib.rs
@@ -6,6 +6,7 @@ pub mod error;
 pub mod onchain;
 pub mod app_key;
 pub mod verify;
+pub mod compat;
 
 pub mod proto {
     tonic::include_proto!("tapp_service");

--- a/tapp-common/src/onchain.rs
+++ b/tapp-common/src/onchain.rs
@@ -108,6 +108,27 @@ pub async fn get_app_image_hashes(
     Err(anyhow!("unexpected getAppInfo return shape"))
 }
 
+/// The app owner via getAppInfo(string). Address::zero() means "not registered"
+/// (the contract returns an empty struct for unknown app ids).
+pub async fn get_app_owner(rpc_url: &str, contract: &str, app_id: &str) -> Result<Address> {
+    let data = calldata("getAppInfo(string)", vec![Token::String(app_id.to_owned())]);
+    let out = call_raw(rpc_url, contract, data).await?;
+    let tuple = ParamType::Tuple(vec![
+        ParamType::Bytes,
+        ParamType::Bytes,
+        ParamType::Array(Box::new(ParamType::Bytes)),
+        ParamType::Address,
+        ParamType::Uint(256),
+    ]);
+    let tokens = decode(&[tuple], &out).map_err(|e| anyhow!("decode getAppInfo: {}", e))?;
+    if let Some(Token::Tuple(fields)) = tokens.into_iter().next() {
+        if let Token::Address(owner) = &fields[3] {
+            return Ok(*owner);
+        }
+    }
+    Err(anyhow!("unexpected getAppInfo return shape"))
+}
+
 /// Registered node signer addresses for an app (getNodeList).
 pub async fn get_node_list(rpc_url: &str, contract: &str, app_id: &str) -> Result<Vec<Address>> {
     let data = calldata("getNodeList(string)", vec![Token::String(app_id.to_owned())]);


### PR DESCRIPTION
Promotes 6 merged changes from `dev` to `main` (27 files, +962/−112):

## Features

- **#26 — runtime CLI↔server/contract version-compatibility check**: tapp-cli compares its MAJOR.MINOR against the server's and the on-chain contract's `version()` at runtime; warns on mismatch (no hard reject), per `docs/VERSIONING.md`.
- **#28 — `start-app --register-onchain`**: idempotent on-chain registration BEFORE the app's containers start. Server gains a `measure_only` StartApp mode (pull images + compute compose/volumes/image hashes without starting containers, returned via TaskResult); `GetAppKey` is create-if-missing so the signer is available pre-start. Not registered → `registerApp`; signer missing from node list → `addNode`; already a node → skip. e2e-tested on Galileo testnet (all three paths, real txs).
- **#29 — GCP confidential image build kit Stage C**: publish stage + 3-stage pipeline documentation.
- **#35 — `GetSecretResource` derivation-material passthrough** (closes #33): optional `GetSecretResourceRequest.material = 2` (hex, opaque to tapp) forwarded verbatim to KMS `/app-key`, which binds it into the derived key alongside `app_id` — lets the AgenticID attestor derive per-agent seal keys directly from KMS (0gfoundation/0g-agentic-id#35). Empty/absent material produces a JSON body byte-identical to today's; LOCAL-ACCESS-ONLY check and signature scheme unchanged. Wiremock-tested (forwarded verbatim / omitted when empty).

## Fixes

- **#30 — `start-service` is idempotent** (fixes #27): dropped the broken "already running" pre-check (substring match false-positived on sibling services like `sandbox` vs `sandbox-redis`, permanently blocking restart-after-stop). `docker compose up -d` semantics now apply: stopped→start, running→no-op, running+`--pull`→recreate with re-measure. e2e-tested.
- **#34 — bound file-log growth + move CVM logs off the RAM rootfs** (fixes #23): new `logging.max_log_files` (default 7) caps kept daily files; `init_tracing` also prunes stale files at startup (tracing-appender only prunes at in-process rotation — verified empirically). gcp-cvm build now writes logs to `/data/log/tapp/` with `RequiresMountsFor=/data` (same fail-loud policy as docker/containerd). Unit + real-binary e2e tested (10 seeded files, cap 3 → 3 remain; 5-min MINUTELY rotation run confirms rotation-time prune).

## Compatibility

- Proto changes are additive (`StartAppRequest.measure_only`, `TaskResult` hash fields, `GetSecretResourceRequest.material`) — old CLIs/callers work against the new server unchanged.
- New CLI's `--register-onchain` against an old server aborts safely ("Server did not return measurements") instead of registering empty hashes.
- `start-service` on an already-running service now succeeds (no-op) instead of erroring.
- `logging.max_log_files` defaults via serde — existing configs untouched; empty `material` keeps the KMS request byte-identical, so old KMS nodes are unaffected.

`Cargo.lock` verified consistent (`cargo metadata --locked` passes on dev).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Version tracking

| Artifact | main | this PR | Bump reason (per docs/VERSIONING.md) |
|---|---|---|---|
| tapp-server | 0.1.1 | **0.2.0** | MINOR — gRPC interface changed: #28 adds `StartAppRequest.measure_only` + `TaskResult` measurement fields; #30 changes StartService already-running semantics; #35 adds `GetSecretResourceRequest.material`; #34 adds `logging.max_log_files` config |
| tapp-cli | 0.1.0 | **0.2.0** | MINOR — runtime version-compat warnings (#26) + new user-facing flags: `start-app --register-onchain/--rpc-url/--contract/--stake-wei` (#28); 0.1.1 was an interim bump on dev |
| tapp-common | 0.1.0 | 0.1.0 | internal, additive only (`get_app_owner`; proto regenerates from the updated .proto) |
| TappRegistry (contract) | 0.1.0 | 0.1.0 | untouched |

After merge, tag per the release workflow: `tapp-server-v0.2.0`, `tapp-cli-v0.2.0`.
