### PR TITLE
fix(logging): bound file-log growth + move CVM logs off the RAM rootfs

### DIFF
--- a/examples/config.toml
+++ b/examples/config.toml
@@ -3,7 +3,8 @@
 [logging]
 level = "info"  # Log level: "trace", "debug", "info", "warn", "error"
 format = "json" # Log format: "json" or "pretty"
-# file_path = "/var/log/tapp/app.log"  # Optional: log to file
+# file_path = "/var/log/tapp/app.log"  # Optional: log to file (daily rotation)
+# max_log_files = 7  # Rotated daily files to keep; oldest deleted (default: 7)
 
 [server]
 bind_address = "0.0.0.0:50051"

--- a/gcp-cvm/build-gcp-tapp.sh
+++ b/gcp-cvm/build-gcp-tapp.sh
@@ -80,6 +80,9 @@ cat > "$TMPD/tapp-server.service" <<'EOF'
 Description=TAPP gRPC Server - Trusted Application
 After=network.target
 Wants=network.target
+# File logs live on the persistent /data disk (RAM rootfs would grow unbounded,
+# issue #23) — same fail-loud policy as docker/containerd: no /data, no start.
+RequiresMountsFor=/data
 
 [Service]
 Type=simple
@@ -104,7 +107,10 @@ cat > "$TMPD/config.toml" <<EOF
 [logging]
 level = "info"
 format = "pretty"
-file_path = "/var/log/tapp/"
+# On the persistent /data disk, NOT the RAM rootfs (rw_overlay="ram") — file
+# logs on "/" consume RAM and are lost on reboot (issue #23). tapp-server keeps
+# at most `max_log_files` daily files (default 7).
+file_path = "/data/log/tapp/"
 
 [server.permission]
 enabled = true

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,6 +30,12 @@ pub struct LoggingConfig {
 
     /// Log file path (if None, logs to stdout)
     pub file_path: Option<PathBuf>,
+
+    /// Maximum number of rotated (daily) log files to keep; oldest are deleted.
+    /// Bounds total log growth — without a cap, daily rotation still grows
+    /// unbounded and can exhaust the RAM rootfs on CVM images (issue #23).
+    #[serde(default = "default_max_log_files")]
+    pub max_log_files: usize,
 }
 
 /// Main configuration structure for TAPP service
@@ -218,6 +224,10 @@ fn default_log_format() -> String {
     "json".to_string()
 }
 
+fn default_max_log_files() -> usize {
+    7
+}
+
 impl Default for KbsConfig {
     fn default() -> Self {
         Self {
@@ -268,6 +278,7 @@ impl Default for LoggingConfig {
             level: default_log_level(),
             format: default_log_format(),
             file_path: None,
+            max_log_files: default_max_log_files(),
         }
     }
 }

--- a/src/kms_client.rs
+++ b/src/kms_client.rs
@@ -19,7 +19,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let client = KmsClient::new(vec![server.uri()]);
+        let client = KmsClient::new(vec![server.uri()], &Default::default());
         let result = client
             .get_encrypted_secret("myapp", 1234567890, "pubkey_hex", "sig_hex")
             .await
@@ -49,7 +49,7 @@ mod tests {
             .mount(&good_server)
             .await;
 
-        let client = KmsClient::new(vec![bad_server.uri(), good_server.uri()]);
+        let client = KmsClient::new(vec![bad_server.uri(), good_server.uri()], &Default::default());
         let result = client
             .get_encrypted_secret("myapp", 1234567890, "pubkey_hex", "sig_hex")
             .await
@@ -67,7 +67,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let client = KmsClient::new(vec![server.uri()]);
+        let client = KmsClient::new(vec![server.uri()], &Default::default());
         let result = client
             .get_encrypted_secret("myapp", 1234567890, "pubkey_hex", "sig_hex")
             .await;
@@ -77,7 +77,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_no_nodes_configured() {
-        let client = KmsClient::new(vec![]);
+        let client = KmsClient::new(vec![], &Default::default());
         let result = client
             .get_encrypted_secret("myapp", 1234567890, "pubkey_hex", "sig_hex")
             .await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1504,6 +1504,29 @@ impl TappService for TappServiceImpl {
 }
 
 /// Initialize tracing based on configuration
+/// Delete the oldest `{prefix}.*` daily log files so at most `max_files - 1`
+/// remain (the appender then creates/opens today's file, bringing the total
+/// back to `max_files`). Filenames embed the date (`prefix.yyyy-MM-dd`), so
+/// lexicographic order == chronological order. Best-effort: IO errors are
+/// ignored — logging setup must not fail because a stale file can't be removed.
+fn prune_old_log_files(directory: &std::path::Path, prefix: &str, max_files: usize) {
+    let Ok(entries) = std::fs::read_dir(directory) else {
+        return;
+    };
+    let wanted = format!("{}.", prefix);
+    let mut files: Vec<String> = entries
+        .filter_map(|e| e.ok()?.file_name().into_string().ok())
+        .filter(|name| name.starts_with(&wanted))
+        .collect();
+    if files.len() < max_files {
+        return;
+    }
+    files.sort();
+    for name in &files[..files.len() - (max_files - 1)] {
+        let _ = std::fs::remove_file(directory.join(name));
+    }
+}
+
 pub fn init_tracing(config: &config::LoggingConfig) -> TappResult<()> {
     use tracing_subscriber::{
         fmt::{self, format::FmtSpan},
@@ -1565,6 +1588,13 @@ pub fn init_tracing(config: &config::LoggingConfig) -> TappResult<()> {
         // Keep at most `max_log_files` daily files — without a retention cap the
         // rotated files accumulate forever, which on RAM-rootfs CVM images means
         // unbounded RAM growth (issue #23).
+        //
+        // tracing-appender only prunes inside refresh_writer, i.e. when the date
+        // rolls over WHILE the process is running — files left by previous runs
+        // survive until the first in-process midnight, and a process that never
+        // lives past midnight never prunes at all. Prune at startup ourselves.
+        prune_old_log_files(directory, file_name_prefix, config.max_log_files.max(1));
+
         let file_appender = RollingFileAppender::builder()
             .rotation(Rotation::DAILY)
             .filename_prefix(file_name_prefix)
@@ -1610,6 +1640,44 @@ pub fn init_tracing(config: &config::LoggingConfig) -> TappResult<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_prune_old_log_files() {
+        let dir = std::env::temp_dir().join(format!("tapp-prune-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        // 10 accumulated daily files + an unrelated file that must survive
+        for d in 1..=10 {
+            std::fs::write(dir.join(format!("app.2026-07-{:02}", d)), "old").unwrap();
+        }
+        std::fs::write(dir.join("other.txt"), "keep").unwrap();
+
+        prune_old_log_files(&dir, "app", 7);
+
+        let mut files: Vec<String> = std::fs::read_dir(&dir)
+            .unwrap()
+            .map(|e| e.unwrap().file_name().into_string().unwrap())
+            .collect();
+        files.sort();
+        // newest 6 kept (appender's new file for today makes 7), oldest 4 gone
+        assert_eq!(
+            files,
+            vec![
+                "app.2026-07-05",
+                "app.2026-07-06",
+                "app.2026-07-07",
+                "app.2026-07-08",
+                "app.2026-07-09",
+                "app.2026-07-10",
+                "other.txt"
+            ]
+        );
+
+        // fewer files than the cap -> untouched
+        prune_old_log_files(&dir, "app", 7);
+        assert_eq!(std::fs::read_dir(&dir).unwrap().count(), 7);
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
 
     #[test]
     fn test_validate_app_id() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1562,7 +1562,18 @@ pub fn init_tracing(config: &config::LoggingConfig) -> TappResult<()> {
             reason: format!("Cannot create log directory: {}", e),
         })?;
 
-        let file_appender = RollingFileAppender::new(Rotation::DAILY, directory, file_name_prefix);
+        // Keep at most `max_log_files` daily files — without a retention cap the
+        // rotated files accumulate forever, which on RAM-rootfs CVM images means
+        // unbounded RAM growth (issue #23).
+        let file_appender = RollingFileAppender::builder()
+            .rotation(Rotation::DAILY)
+            .filename_prefix(file_name_prefix)
+            .max_log_files(config.max_log_files.max(1))
+            .build(directory)
+            .map_err(|e| error::ConfigError::InvalidValue {
+                field: "logging.file_path".to_string(),
+                reason: format!("Cannot create log appender: {}", e),
+            })?;
 
         let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
         std::mem::forget(_guard);


### PR DESCRIPTION
Fixes #23 — tapp-server file logs on the GCP CVM live on the RAM-backed rootfs overlay and grow without bound.

Two halves, both needed:

**Code — retention cap (bounds growth anywhere):**
- `RollingFileAppender` switches to the builder with `max_log_files` — daily rotation alone never deletes old files, so total size was still unbounded, just split per day.
- New `logging.max_log_files` config field, default **7** (kept files; oldest deleted). Existing configs are untouched (`serde(default)`).
- **Startup prune**: tracing-appender's `max_log_files` only prunes when the date rolls over *while the process is running* (verified empirically against 0.2.3's `refresh_writer`) — files from previous runs survive until the first in-process midnight, and a process that never lives past midnight never prunes. `init_tracing` now prunes `{prefix}.*` at startup, best-effort.

**Build — relocate off the RAM rootfs:**
- `gcp-cvm/build-gcp-tapp.sh`: `file_path = "/data/log/tapp/"` (persistent data disk) instead of `/var/log/tapp/`.
- `tapp-server.service` gains `RequiresMountsFor=/data` — same fail-loud policy the build already applies to docker/containerd (never silently write to the RAM root when the data disk is missing).

Also fixes the stale `KmsClient::new` arity in `kms_client` tests (predates the retry-config parameter; lib tests didn't compile on dev). Same textual fix as in #35 — merges cleanly whichever lands first.

**Tested:**
- Unit test for the startup prune (`test_prune_old_log_files`); full `cargo test -p tapp-server` 24/24.
- E2E with the real binary: seeded 10 old daily files, `max_log_files = 3` → after startup only the 2 newest + today's file remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
