### PR TITLE
fix(cli): update GetSecretResourceRequest for new material field

### DIFF
--- a/tapp-cli/src/main.rs
+++ b/tapp-cli/src/main.rs
@@ -237,6 +237,11 @@ enum Commands {
         /// Application ID
         #[arg(short, long)]
         app_id: String,
+
+        /// Optional hex-encoded derivation material, forwarded verbatim to KMS
+        /// (e.g. AgenticID: chainId || contractAddress || sealId)
+        #[arg(short, long, default_value = "")]
+        material: String,
     },
 
     /// Start a specific service within an app
@@ -630,8 +635,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         } => {
             get_app_secret_key(&cli.server, app_id, json, x25519).await?;
         }
-        Commands::GetSecretResource { app_id } => {
-            get_secret_resource(&cli.server, app_id).await?;
+        Commands::GetSecretResource { app_id, material } => {
+            get_secret_resource(&cli.server, app_id, material).await?;
         }
         Commands::StartService {
             app_id,
@@ -1583,11 +1588,13 @@ async fn get_app_secret_key(
 async fn get_secret_resource(
     server: &str,
     app_id: String,
+    material: String,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let mut client = create_client(server).await?;
 
     let request = Request::new(GetSecretResourceRequest {
         app_id: app_id.clone(),
+        material,
     });
 
     let response = match client.get_secret_resource(request).await {


### PR DESCRIPTION
## Problem

Release pipeline run [29242499831](https://github.com/0gfoundation/0g-tapp/actions/runs/29242499831) (tag `v0.2.0-test`) failed to compile:

```
error[E0063]: missing field `material` in initializer of `GetSecretResourceRequest`
error: could not compile `tapp-cli` (bin "tapp-cli") due to 1 previous error
```

PR #35 added the `material` field to `GetSecretResourceRequest` and updated the server handler, but tapp-cli's request initializer was not updated. `cargo build --release --workspace` (what the release Dockerfile runs) has been broken on `dev` since then.

## Fix

- Fill the new field in the CLI request, exposed as an optional `--material` / `-m` flag on `get-secret-resource` (hex-encoded, forwarded verbatim to KMS — e.g. AgenticID `chainId || contractAddress || sealId`).
- Default is empty → identical behavior to before #35.

## Verification

- `cargo build --release --workspace` passes.
- `tapp-cli get-secret-resource --help` shows the new flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)