### PR TITLE
perf(ci): cache toolchain layers, official rustup source, drop -j1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,17 +29,37 @@ jobs:
     - name: Install cosign
       uses: sigstore/cosign-installer@v3
 
+    # The toolchain stage (yum + rustup, no project sources) is cached in the
+    # GitHub Actions cache — it only rebuilds when the Dockerfile changes.
+    # Cached separately from the full build so the multi-GB cargo build layer
+    # never gets uploaded to the cache.
+    - name: Build toolchain image (cached)
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: reproducible_build/Dockerfile
+        target: toolchain
+        tags: 0g-tapp-toolchain
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
     - name: Build binaries with Docker
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: reproducible_build/Dockerfile
+        tags: 0g-tapp-builder
+        load: true
+        cache-from: type=gha
+
+    - name: Extract binaries
       run: |
-        # Build the builder image
-        docker build -f reproducible_build/Dockerfile -t 0g-tapp-builder .
-        
         # Create output directory
         mkdir -p artifacts
-        
+
         # Extract binaries from container
         docker run --rm -v $(pwd)/artifacts:/artifacts 0g-tapp-builder
-        
+
         # Verify binaries exist
         ls -lh artifacts/
         file artifacts/*

--- a/reproducible_build/Dockerfile
+++ b/reproducible_build/Dockerfile
@@ -17,9 +17,18 @@
 # Usage:
 #   docker build -f Dockerfile -t 0g-tapp-builder /path/to/0g-tapp
 #   docker run --rm -v $(pwd)/artifacts:/artifacts 0g-tapp-builder
+#
+# Building from inside China? Point rustup at a domestic mirror:
+#   docker build -f Dockerfile -t 0g-tapp-builder \
+#     --build-arg RUSTUP_DIST_SERVER=https://mirrors.ustc.edu.cn/rust-static \
+#     --build-arg RUSTUP_UPDATE_ROOT=https://mirrors.ustc.edu.cn/rust-static/rustup \
+#     /path/to/0g-tapp
 # =============================================================================
 
-FROM alibaba-cloud-linux-3-registry.cn-hangzhou.cr.aliyuncs.com/alinux3/alinux3:latest
+# --- Stage 1: toolchain — OS packages + Rust, no project sources. -----------
+# Kept as a separate stage so CI can cache it: none of these layers depend on
+# the source tree, and mirror choice does not affect the bits installed.
+FROM alibaba-cloud-linux-3-registry.cn-hangzhou.cr.aliyuncs.com/alinux3/alinux3:latest AS toolchain
 
 # Set region for Aliyun services
 ARG REGION=cn-beijing
@@ -43,27 +52,30 @@ RUN yum install -y yum-utils-4.0.21-25.1.al8.noarch && \
     sgxsdk-2.23.100.2-1.al8.x86_64 && \
     yum clean all
 
-# Configure Rust installation with Aliyun mirrors
-#ENV RUSTUP_UPDATE_ROOT=https://mirrors.aliyun.com/rustup/rustup
-#ENV RUSTUP_DIST_SERVER=https://mirrors.aliyun.com/rustup
-ENV RUSTUP_DIST_SERVER=https://mirrors.ustc.edu.cn/rust-static
-ENV RUSTUP_UPDATE_ROOT=https://mirrors.ustc.edu.cn/rust-static/rustup
+# Rust download source: official by default (GitHub runners are US-based and
+# domestic mirrors throttle them); override via --build-arg when building from
+# inside China (see header).
+ARG RUSTUP_DIST_SERVER=https://static.rust-lang.org
+ARG RUSTUP_UPDATE_ROOT=https://static.rust-lang.org/rustup
+ENV RUSTUP_DIST_SERVER=${RUSTUP_DIST_SERVER}
+ENV RUSTUP_UPDATE_ROOT=${RUSTUP_UPDATE_ROOT}
 ENV CARGO_HOME=/usr/local/cargo
 ENV RUSTUP_HOME=/usr/local/rustup
 ENV PATH=/usr/local/cargo/bin:$PATH
 
-# Reproducible build settings
+# Reproducible build settings. Compilation parallelism is deliberately NOT
+# pinned: cargo job count only affects scheduling, not codegen — -j1 and -j4
+# builds of this workspace produce sha256-identical binaries.
 ENV SOURCE_DATE_EPOCH=1609459200
 ENV RUSTFLAGS="-C link-arg=-Wl,--build-id=none --remap-path-prefix=/build=/src"
-ENV CARGO_BUILD_JOBS=1
 
 # Install Rust toolchain (version specified in rust-toolchain.toml: 1.91.0)
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.91.0 && \
     rustc --version && \
     cargo --version
 
-ENV RUSTUP_UPDATE_ROOT=https://mirrors.aliyun.com/rustup/rustup
-ENV RUSTUP_DIST_SERVER=https://mirrors.aliyun.com/rustup
+# --- Stage 2: build — copy sources and compile. ------------------------------
+FROM toolchain AS builder
 
 # Set working directory
 WORKDIR /build


### PR DESCRIPTION
## Problem

Release run [29242499831](https://github.com/0gfoundation/0g-tapp/actions/runs/29242499831) took **2h23m**. Breakdown from the log timestamps:

| Stage | Time | Cause |
|---|---|---|
| rustup install (USTC mirror) | **88 min** | US runner throttled by the domestic mirror |
| yum install (Aliyun OSS) | 11 min | cross-ocean download |
| cargo build | 13 min (died on compile error) | `CARGO_BUILD_JOBS=1` forces single-threaded compile on a 4-core runner |
| Queue | 31 min | org runner quota, unrelated to this workflow |

Even on a good day the pipeline takes ~27 min, all of it repeated from scratch on every run.

## Changes

1. **Split the Dockerfile into `toolchain` + `builder` stages** and cache the toolchain stage (yum + rustup, no project sources) in the GitHub Actions cache via `docker/build-push-action`. It only rebuilds when the Dockerfile changes; the multi-GB cargo build layer is never uploaded to the cache.
2. **rustup defaults to `static.rust-lang.org`** — fast from US runners, and immune to domestic-mirror throttling on cold builds. Builds from inside China can keep using a mirror via `--build-arg RUSTUP_DIST_SERVER=...` (documented in the Dockerfile header). Mirror choice does not affect the installed toolchain bits.
3. **Drop `CARGO_BUILD_JOBS=1`** — cargo job parallelism only affects scheduling, not codegen, so it was costing 3× compile time for nothing.

## Reproducibility verification (for change 3)

Clean-room comparison on a 4-core machine, identical source/target paths, `SOURCE_DATE_EPOCH` + repo RUSTFLAGS, target dir wiped between builds:

```
bc480ccefd1e...c05583  out_j1/tapp-server
bc480ccefd1e...c05583  out_j4/tapp-server   ← identical
6860e83e0256...142285  out_j1/tapp-cli
6860e83e0256...142285  out_j4/tapp-cli      ← identical
```

Same-path `-j1` vs `-j4` builds are sha256-identical, which simultaneously demonstrates rebuild determinism and parallelism independence. (Side note for anyone re-verifying by hand: the *absolute target dir path* is embedded via OUT_DIR-generated proto code, so builds from different target dirs will never match — in Docker the path is constant `/build` and remapped by RUSTFLAGS.)

The `-j1` build took 14m37s vs 5m22s for `-j4` on the same box.

## Expected effect

- Warm cache: **~5–8 min** end-to-end
- Cold cache (Dockerfile changed): ~15 min
- vs current 27 min baseline / 2h+ when mirrors throttle

The toolchain stage was also built locally with the official rustup source to validate the multi-stage split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)