### PR TITLE
fix(ci): reference-values PR write perms + release auto-trigger (RELEASE_PAT)

### DIFF
--- a/.github/workflows/build-cvm.yml
+++ b/.github/workflows/build-cvm.yml
@@ -41,6 +41,12 @@ concurrency:
   group: build-cvm-${{ inputs.version || github.event.release.tag_name }}-${{ inputs.owner || vars.OWNER_ADDRESS }}
   cancel-in-progress: false
 
+# The reference-values step pushes a refvalues/* branch and opens a PR into dev with GITHUB_TOKEN;
+# the default token is read-only, so grant the writes it needs (else: "denied to github-actions[bot]" 403).
+permissions:
+  contents: write        # push the refvalues/* branch
+  pull-requests: write   # open the reference-values PR
+
 jobs:
   build:
     runs-on: [self-hosted, alinux, cvm-builder]

--- a/.github/workflows/build-cvm.yml
+++ b/.github/workflows/build-cvm.yml
@@ -147,7 +147,9 @@ jobs:
         if: ${{ env.PUBLISH == 'true' }}
         run: gcp-cvm/ci/open-refvalues-pr.sh "$CLOUD" "$VERSION" "${{ matrix.env }}" "$OWNER"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # PAT so `gh pr create` works even if the org disables "Actions create/approve PRs".
+          # git push still uses GITHUB_TOKEN via the permissions block above. Falls back if unset.
+          GH_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Cleanup build artifacts + revoke GCP credential
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,6 +94,10 @@ jobs:
       uses: softprops/action-gh-release@v1
       if: startsWith(github.ref, 'refs/tags/')
       with:
+        # Create the release with a PAT (not the default GITHUB_TOKEN): releases created by
+        # GITHUB_TOKEN do NOT fire `on: release` in other workflows (anti-recursion), so the
+        # build-cvm auto-trigger would never run. Falls back to GITHUB_TOKEN if the secret is unset.
+        token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
         files: |
           artifacts/${{ env.BINARY_NAME_SERVER }}
           artifacts/${{ env.BINARY_NAME_CLI }}


### PR DESCRIPTION
Two coupled fixes so the CI chain runs fully green **and** auto-triggers on release:

1. **Open-PR write perms** — `permissions: contents/pull-requests: write` (default GITHUB_TOKEN is read-only → the end-to-end run failed at `git push` with `denied to github-actions[bot]` 403).
2. **Release auto-trigger** — `build.yml` creates the release with `secrets.RELEASE_PAT` instead of GITHUB_TOKEN. Releases created by GITHUB_TOKEN don't fire `on: release` in other workflows (anti-recursion), which is why publishing v0.2.0-test did **not** trigger build-cvm. A PAT-created release does.
3. build-cvm Open-PR uses `RELEASE_PAT` for `gh pr create` too (in case the org disables Actions-created PRs).

**Requires**: repo secret `RELEASE_PAT` — a fine-grained PAT scoped to `0g-tapp` with **Contents: write** + **Pull requests: write**. Both token refs fall back to GITHUB_TOKEN if the secret is unset (so merging this is safe before the secret exists; auto-trigger just won't fire until it's set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)