### PR TITLE
fix(main): CLI material compile fix + CI build speed (cherry-picks from dev)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,17 +29,37 @@ jobs:
     - name: Install cosign
       uses: sigstore/cosign-installer@v3
 
+    # The toolchain stage (yum + rustup, no project sources) is cached in the
+    # GitHub Actions cache — it only rebuilds when the Dockerfile changes.
+    # Cached separately from the full build so the multi-GB cargo build layer
+    # never gets uploaded to the cache.
+    - name: Build toolchain image (cached)
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: reproducible_build/Dockerfile
+        target: toolchain
+        tags: 0g-tapp-toolchain
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
     - name: Build binaries with Docker
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: reproducible_build/Dockerfile
+        tags: 0g-tapp-builder
+        load: true
+        cache-from: type=gha
+
+    - name: Extract binaries
       run: |
-        # Build the builder image
-        docker build -f reproducible_build/Dockerfile -t 0g-tapp-builder .
-        
         # Create output directory
         mkdir -p artifacts
-        
+
         # Extract binaries from container
         docker run --rm -v $(pwd)/artifacts:/artifacts 0g-tapp-builder
-        
+
         # Verify binaries exist
         ls -lh artifacts/
         file artifacts/*

--- a/reproducible_build/Dockerfile
+++ b/reproducible_build/Dockerfile
@@ -17,9 +17,18 @@
 # Usage:
 #   docker build -f Dockerfile -t 0g-tapp-builder /path/to/0g-tapp
 #   docker run --rm -v $(pwd)/artifacts:/artifacts 0g-tapp-builder
+#
+# Building from inside China? Point rustup at a domestic mirror:
+#   docker build -f Dockerfile -t 0g-tapp-builder \
+#     --build-arg RUSTUP_DIST_SERVER=https://mirrors.ustc.edu.cn/rust-static \
+#     --build-arg RUSTUP_UPDATE_ROOT=https://mirrors.ustc.edu.cn/rust-static/rustup \
+#     /path/to/0g-tapp
 # =============================================================================
 
-FROM alibaba-cloud-linux-3-registry.cn-hangzhou.cr.aliyuncs.com/alinux3/alinux3:latest
+# --- Stage 1: toolchain — OS packages + Rust, no project sources. -----------
+# Kept as a separate stage so CI can cache it: none of these layers depend on
+# the source tree, and mirror choice does not affect the bits installed.
+FROM alibaba-cloud-linux-3-registry.cn-hangzhou.cr.aliyuncs.com/alinux3/alinux3:latest AS toolchain
 
 # Set region for Aliyun services
 ARG REGION=cn-beijing
@@ -43,27 +52,30 @@ RUN yum install -y yum-utils-4.0.21-25.1.al8.noarch && \
     sgxsdk-2.23.100.2-1.al8.x86_64 && \
     yum clean all
 
-# Configure Rust installation with Aliyun mirrors
-#ENV RUSTUP_UPDATE_ROOT=https://mirrors.aliyun.com/rustup/rustup
-#ENV RUSTUP_DIST_SERVER=https://mirrors.aliyun.com/rustup
-ENV RUSTUP_DIST_SERVER=https://mirrors.ustc.edu.cn/rust-static
-ENV RUSTUP_UPDATE_ROOT=https://mirrors.ustc.edu.cn/rust-static/rustup
+# Rust download source: official by default (GitHub runners are US-based and
+# domestic mirrors throttle them); override via --build-arg when building from
+# inside China (see header).
+ARG RUSTUP_DIST_SERVER=https://static.rust-lang.org
+ARG RUSTUP_UPDATE_ROOT=https://static.rust-lang.org/rustup
+ENV RUSTUP_DIST_SERVER=${RUSTUP_DIST_SERVER}
+ENV RUSTUP_UPDATE_ROOT=${RUSTUP_UPDATE_ROOT}
 ENV CARGO_HOME=/usr/local/cargo
 ENV RUSTUP_HOME=/usr/local/rustup
 ENV PATH=/usr/local/cargo/bin:$PATH
 
-# Reproducible build settings
+# Reproducible build settings. Compilation parallelism is deliberately NOT
+# pinned: cargo job count only affects scheduling, not codegen — -j1 and -j4
+# builds of this workspace produce sha256-identical binaries.
 ENV SOURCE_DATE_EPOCH=1609459200
 ENV RUSTFLAGS="-C link-arg=-Wl,--build-id=none --remap-path-prefix=/build=/src"
-ENV CARGO_BUILD_JOBS=1
 
 # Install Rust toolchain (version specified in rust-toolchain.toml: 1.91.0)
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.91.0 && \
     rustc --version && \
     cargo --version
 
-ENV RUSTUP_UPDATE_ROOT=https://mirrors.aliyun.com/rustup/rustup
-ENV RUSTUP_DIST_SERVER=https://mirrors.aliyun.com/rustup
+# --- Stage 2: build — copy sources and compile. ------------------------------
+FROM toolchain AS builder
 
 # Set working directory
 WORKDIR /build

--- a/tapp-cli/src/main.rs
+++ b/tapp-cli/src/main.rs
@@ -237,6 +237,11 @@ enum Commands {
         /// Application ID
         #[arg(short, long)]
         app_id: String,
+
+        /// Optional hex-encoded derivation material, forwarded verbatim to KMS
+        /// (e.g. AgenticID: chainId || contractAddress || sealId)
+        #[arg(short, long, default_value = "")]
+        material: String,
     },
 
     /// Start a specific service within an app
@@ -630,8 +635,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         } => {
             get_app_secret_key(&cli.server, app_id, json, x25519).await?;
         }
-        Commands::GetSecretResource { app_id } => {
-            get_secret_resource(&cli.server, app_id).await?;
+        Commands::GetSecretResource { app_id, material } => {
+            get_secret_resource(&cli.server, app_id, material).await?;
         }
         Commands::StartService {
             app_id,
@@ -1583,11 +1588,13 @@ async fn get_app_secret_key(
 async fn get_secret_resource(
     server: &str,
     app_id: String,
+    material: String,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let mut client = create_client(server).await?;
 
     let request = Request::new(GetSecretResourceRequest {
         app_id: app_id.clone(),
+        material,
     });
 
     let response = match client.get_secret_resource(request).await {


### PR DESCRIPTION
Cherry-picks the two commits main is missing from dev — without them the `v0.2.0` tag build ([run 29263922931](https://github.com/0gfoundation/0g-tapp/actions/runs/29263922931), cancelled) runs the old slow pipeline and then dies on the same compile error as the previous release attempt.

## 1. `fix(cli)`: missing `material` field (PR #36 on dev)

main already has the `material` proto field (from #35 via the dev→main merge), but tapp-cli's `GetSecretResourceRequest` initializer was never updated → `cargo build --workspace` fails with E0063. Exposes it as an optional `--material` flag (default empty, unchanged behavior).

## 2. `perf(ci)`: pipeline speed (PR #38 on dev)

- Dockerfile split into cached `toolchain` stage (yum + rustup) + `builder` stage; toolchain layers cached in GHA cache
- rustup defaults to official `static.rust-lang.org` (the USTC mirror throttled a US runner for 88 min on run 29242499831); domestic mirror still available via `--build-arg`
- drop `CARGO_BUILD_JOBS=1` — verified `-j1`/`-j4` builds are sha256-identical

Measured on dev (runs 29258659236 / 29260443411): cold cache 24 min, **warm cache 9 min**, cross-runner binaries sha256-identical.

## Verification

`cargo build --release --workspace` passes on this branch (main + cherry-picks).

After merge: re-tag `v0.2.0` on main to rerun the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)