### PR TITLE
fix(ci): include owner in published GCP image name/family (avoid collision)

### DIFF
--- a/.github/workflows/build-cvm.yml
+++ b/.github/workflows/build-cvm.yml
@@ -129,8 +129,13 @@ jobs:
         if: ${{ env.PUBLISH == 'true' }}
         run: |
           cd gcp-cvm
-          IMG="${{ steps.v.outputs.imgbase }}-${VERSION//./-}"
-          IMAGE_FAMILY="${{ steps.v.outputs.imgbase }}" \
+          # owner is a MEASURED dimension → include it in the image name + family, else different owners
+          # (same version×env) collide on the GCP image name (publish refuses an existing name).
+          # lowercased for GCP naming rules ([a-z][-a-z0-9]*, max 63 chars):
+          #   og-tdx-dev-<ver>-0x<40hex> ≈ 60 chars, within budget for normal version tags.
+          OWNER_TAG="$(printf '%s' "$OWNER" | tr 'A-Z' 'a-z')"
+          IMG="${{ steps.v.outputs.imgbase }}-${VERSION//./-}-${OWNER_TAG}"
+          IMAGE_FAMILY="${{ steps.v.outputs.imgbase }}-${OWNER_TAG}" \
             ./publish-gcp-image.sh "out-${{ matrix.env }}.qcow2" "$IMG"
 
       - name: Reference values — compute, write, register on AS

--- a/gcp-cvm/publish-gcp-image.sh
+++ b/gcp-cvm/publish-gcp-image.sh
@@ -21,6 +21,11 @@ set -euo pipefail
 IMG="${1:?usage: $0 <image.qcow2> <gcp-image-name>}"
 NAME="${2:?usage: $0 <image.qcow2> <gcp-image-name>}"
 [ -f "$IMG" ] || { echo "image not found: $IMG" >&2; exit 1; }
+# GCP image names: ^[a-z]([-a-z0-9]*[a-z0-9])?$, max 63 chars. The name now carries the owner address
+# (~42 chars), so a long version tag could overflow — fail early with a clear message rather than a
+# cryptic gcloud error.
+[ "${#NAME}" -le 63 ] || { echo "image name '$NAME' is ${#NAME} chars (GCP max 63) — shorten the version tag" >&2; exit 1; }
+printf '%s' "$NAME" | grep -Eq '^[a-z]([-a-z0-9]*[a-z0-9])?$' || { echo "image name '$NAME' is not a valid GCP name (^[a-z][-a-z0-9]*[a-z0-9]?$)" >&2; exit 1; }
 
 # ===== Tunables =====
 GCS_BUCKET="${GCS_BUCKET:-gs://tapp-image}"


### PR DESCRIPTION
The published GCP image name was `og-tdx[-dev]-<version>` with **no owner**, so two different owners building the same version×env would **collide on the image name** (publish-gcp-image.sh refuses an already-existing name). Since owner is a measured dimension, bake it into the name **and** family:

- name:   `og-tdx[-dev]-<version>-<owner(lowercased)>`
- family: `og-tdx[-dev]-<owner(lowercased)>`

Owner is lowercased for GCP naming rules (`^[a-z][-a-z0-9]*[a-z0-9]?$`, max 63). `og-tdx-dev-<ver>-0x<40hex>` ≈ 60 chars — within budget for normal version tags. Added a length/pattern guard in publish-gcp-image.sh so an over-long name fails early with a clear message instead of a cryptic gcloud error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)