### PR TITLE
Drop build-cvm on:release auto-trigger (dispatch-only)

### DIFF
--- a/.github/workflows/build-cvm.yml
+++ b/.github/workflows/build-cvm.yml
@@ -5,8 +5,8 @@
 # and network to the shared AS. The cryptpilot 0.8.0 + #128/#130 toolchain is provisioned by
 # ci/setup-toolchain.sh (installs released 0.8.0 + overlays convert #130 / fde-host #128 from the fork).
 #
-# Dimensions (see verifier/reference-values/README.md): version × env × owner.
-#   version = tapp-server release tag (trigger)         → which tapp-server + image name suffix
+# Dimensions (see verifier/reference-values/README.md): cloud × boot_format × env × owner × version.
+#   version = tapp-server release tag                   → which tapp-server + image name suffix
 #   env     = dev (HARDEN=0) | prod (HARDEN=1)          → image variant (og-tdx-dev / og-tdx)
 #   owner   = OWNER_ADDRESS, baked into config.toml     → folded into the initrd measurement,
 #             so it IS an attested dimension (per-owner reference values).
@@ -15,10 +15,8 @@
 name: build-cvm
 
 on:
-  # A published tapp-server release auto-builds the DEFAULT deployment (vars.OWNER_ADDRESS),
-  # both env, and publishes + registers. Custom/per-owner builds use workflow_dispatch below.
-  release:
-    types: [published]
+  # Manual entry point: build a chosen cloud × boot_format × env × owner at a given tapp-server
+  # release version, optionally publishing the image + registering reference values.
   workflow_dispatch:
     inputs:
       version:
@@ -48,7 +46,7 @@ on:
         default: auto
 
 concurrency:
-  group: build-cvm-${{ inputs.cloud || 'gcp' }}-${{ inputs.version || github.event.release.tag_name }}-${{ inputs.owner || vars.OWNER_ADDRESS }}
+  group: build-cvm-${{ inputs.cloud || 'gcp' }}-${{ inputs.version }}-${{ inputs.owner || vars.OWNER_ADDRESS }}
   cancel-in-progress: false
 
 # The reference-values step pushes a refvalues/* branch and opens a PR into dev with GITHUB_TOKEN;
@@ -63,17 +61,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # release (no inputs.env) -> both; dispatch -> the chosen env
-        env: ${{ fromJSON((inputs.env || 'both') == 'both' && '["dev","prod"]' || format('["{0}"]', inputs.env)) }}
+        # env=both -> [dev, prod]; otherwise the single chosen env
+        env: ${{ fromJSON(inputs.env == 'both' && '["dev","prod"]' || format('["{0}"]', inputs.env)) }}
     env:
       # All fixed config lives in repo/org Actions Variables (Settings → Secrets and variables →
       # Actions → Variables), editable without touching this file; the `|| 'default'` is a fallback.
-      # version/owner/publish resolve for BOTH triggers (release event vs dispatch inputs):
-      VERSION: ${{ inputs.version || github.event.release.tag_name }}
+      VERSION: ${{ inputs.version }}
       OWNER: ${{ inputs.owner || vars.OWNER_ADDRESS }}
-      PUBLISH: ${{ github.event_name == 'release' && 'true' || inputs.publish }}
+      PUBLISH: ${{ inputs.publish }}
       # cloud/boot-format dimensions (independent; a CVM = one CLOUD × one BOOT_FORMAT = one measurement
-      # chain). release event -> defaults (cloud=gcp, boot_format auto->grub); dispatch -> chosen inputs.
+      # chain). cloud defaults to gcp; boot_format auto -> grub for gcp / uki for ali.
       CLOUD: ${{ inputs.cloud || 'gcp' }}
       # boot_format 'auto'/'' -> empty, so build-tapp derives it from cloud (gcp->grub, ali->uki)
       BOOT_FORMAT: ${{ (inputs.boot_format == 'auto' || inputs.boot_format == '') && '' || inputs.boot_format }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,10 +114,9 @@ jobs:
       uses: softprops/action-gh-release@v1
       if: startsWith(github.ref, 'refs/tags/')
       with:
-        # Create the release with a PAT (not the default GITHUB_TOKEN): releases created by
-        # GITHUB_TOKEN do NOT fire `on: release` in other workflows (anti-recursion), so the
-        # build-cvm auto-trigger would never run. Falls back to GITHUB_TOKEN if the secret is unset.
-        token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
+        # Default GITHUB_TOKEN is enough: build-cvm no longer auto-triggers on release, so we no
+        # longer need a PAT to dodge the "GITHUB_TOKEN releases don't fire on: release" anti-recursion rule.
+        token: ${{ secrets.GITHUB_TOKEN }}
         files: |
           artifacts/${{ env.BINARY_NAME_SERVER }}
           artifacts/${{ env.BINARY_NAME_CLI }}


### PR DESCRIPTION
Removes the `on: release` auto-trigger from build-cvm; **workflow_dispatch is now the single entry point**.

**Why** (discussed): with the multi-cloud matrix the auto-trigger only ever built one slice — `cloud=gcp` + default owner — so it never produced the ali image and could read as "release built everything" when it hadn't. It was also the *only* reason `build.yml` needed a repo-scoped `RELEASE_PAT` (GITHUB_TOKEN-created releases don't fire `on: release`, anti-recursion). Explicit dispatch is clearer about cloud/owner/env intent.

**Changes**
- `build-cvm.yml`: drop the `release:` trigger + all release-event fallbacks (`github.event.release.tag_name`, `event_name == 'release'`); version/publish now come straight from dispatch inputs.
- `build.yml`: release step back to the default `GITHUB_TOKEN` (no PAT needed).

The reference-values Open-PR step keeps its `RELEASE_PAT || GITHUB_TOKEN` fallback (separate use — opening the refvalues PR; degrades to GITHUB_TOKEN if the secret is later removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)