### PR TITLE
Support UKI reference values in AS registration + policy

### DIFF
--- a/verifier/policy.rego
+++ b/verifier/policy.rego
@@ -5,10 +5,14 @@ import rego.v1
 # =============================================================================
 # 0g-tapp boot-chain verification policy (canonical, tapp-level)
 # =============================================================================
-# Verifies a TDX confidential VM boot chain (shim / grub / kernel / initrd /
-# kernel_cmdline) against an image's reference values. These measurements come from
-# the TDX evidence's uefi_event_logs (RTMR0-2). rootfs integrity is folded into the
-# initrd, so it is not checked separately.
+# Verifies a TDX confidential VM boot chain against an image's reference values.
+# Two boot formats, one policy:
+#   * grub → shim / grub / kernel / initrd / kernel_cmdline (5 components)
+#   * uki  → a single signed EFI (kernel+initrd+cmdline fused) → measurement.uki
+# The measurements come from the TDX evidence's uefi_event_logs (RTMR0-2). rootfs
+# integrity is folded into the initrd (grub) / uki, so it is not checked separately.
+# boot_chain_ok has one rule per format; only the format whose reference values are
+# present fires (the other's ref sets are empty), so an image verifies as exactly one.
 #
 # ONE canonical policy — image-/version-/env-agnostic. What differs per
 # release × {dev,prod} is the REFERENCE VALUES, NOT this logic. The values are NOT
@@ -50,6 +54,9 @@ ref_initrd := {x | some x in qrv("measurement.initrd.SHA-384")}
 # kernel_cmdline may have several allowed values (grub path spellings); OR-match.
 ref_kernel_cmdline := {x | some x in qrv("measurement.kernel_cmdline.SHA-384")}
 
+# uki path: a single measurement covering the whole unified kernel image.
+ref_uki := {x | some x in qrv("measurement.uki.SHA-384")}
+
 # --- Extract component digests from uefi_event_logs ------------------------
 # Digests of EV_EFI_BOOT_SERVICES_APPLICATION events whose device_paths contain `needle`.
 bsa_digests(needle) := {d |
@@ -68,18 +75,34 @@ ipl_digests(prefix) := {d |
 	d := e.digests[_].digest
 }
 
+# All boot-services-application digests (any device path). The UKI is loaded as one
+# such event; we match its (specific, known) reference digest against this set rather
+# than pinning a device-path spelling — an attacker still needs our exact UKI digest.
+all_bsa_digests := {d |
+	some e in input.tdx.uefi_event_logs
+	e.type_name == "EV_EFI_BOOT_SERVICES_APPLICATION"
+	d := e.digests[_].digest
+}
+
 # Non-empty intersection = a measured digest matched a reference value.
 hit(measured, reference) if {
 	some m in measured
 	m in reference
 }
 
+# grub boot chain: all five components must match.
 boot_chain_ok if {
 	hit(bsa_digests("shimx64.efi"), ref_shim)
 	hit(bsa_digests("grubx64.efi"), ref_grub)
 	hit(ipl_digests("/vmlinuz"), ref_kernel)
 	hit(ipl_digests("/initrd"), ref_initrd)
 	hit(ipl_digests("kernel_cmdline:"), ref_kernel_cmdline)
+}
+
+# uki boot chain: the single UKI measurement must match. Fires only for UKI images
+# (ref_uki populated); for grub images ref_uki is empty so this rule is inert.
+boot_chain_ok if {
+	hit(all_bsa_digests, ref_uki)
 }
 
 # --- AR4SI trust claims ----------------------------------------------------

--- a/verifier/register-shared-as.sh
+++ b/verifier/register-shared-as.sh
@@ -52,20 +52,28 @@ INJECTED=$(python3 - "$POLICY" "$REF" <<'PY'
 import sys, json, re
 policy = open(sys.argv[1]).read()
 ref = json.load(open(sys.argv[2]))
+# grub uses 5 components, uki uses 1 — inject a literal set per rule (empty set() when
+# the key is absent), so whichever format the image is, only its boot_chain_ok branch
+# in policy.rego has non-empty reference sets and fires. Require ≥1 value overall.
 keymap = {
     "ref_shim": "measurement.shim.SHA-384",
     "ref_grub": "measurement.grub.SHA-384",
     "ref_kernel": "measurement.kernel.SHA-384",
     "ref_initrd": "measurement.initrd.SHA-384",
     "ref_kernel_cmdline": "measurement.kernel_cmdline.SHA-384",
+    "ref_uki": "measurement.uki.SHA-384",
 }
+nonempty = 0
 for rule, key in keymap.items():
     vals = [v for v in ref.get(key, []) if isinstance(v, str) and v]
-    if not vals:
-        sys.stderr.write(f"error: {key} empty in reference file\n"); sys.exit(1)
-    literal = "{" + ", ".join('"%s"' % v for v in vals) + "}"
+    nonempty += len(vals)
+    literal = ("{" + ", ".join('"%s"' % v for v in vals) + "}") if vals else "set()"
     # replace the rule's RHS (the qrv(...) set comprehension) with the literal set
-    policy = re.sub(rule + r" := \{x \| some x in qrv\([^)]*\)\}", f"{rule} := {literal}", policy, count=1)
+    policy, n = re.subn(rule + r" := \{x \| some x in qrv\([^)]*\)\}", f"{rule} := {literal}", policy, count=1)
+    if n != 1:
+        sys.stderr.write(f"error: could not inject {rule} (policy.rego rule/regex mismatch)\n"); sys.exit(1)
+if nonempty == 0:
+    sys.stderr.write("error: reference file has no measurement.*.SHA-384 values\n"); sys.exit(1)
 sys.stdout.write(policy)
 PY
 )


### PR DESCRIPTION
The `gcp + boot_format=uki` validation run failed at **Reference values → register on AS** with `error: measurement.shim.SHA-384 empty`. Build, GCP publish, and reference-value extraction (`measurement.uki.SHA-384`) all succeeded — only the policy-registration side was still grub-only.

## Fix
- **`register-shared-as.sh`**: inject a literal set for every known rule (grub's 5 + `ref_uki`), using an empty `set()` when the key is absent, instead of erroring on missing grub keys. Require ≥1 value overall.
- **`policy.rego`**: add `ref_uki`, an `all_bsa_digests` helper, and a second `boot_chain_ok` branch that matches the (specific, known) UKI digest against any `EV_EFI_BOOT_SERVICES_APPLICATION` event — no device-path pinning needed, and an attacker still needs our exact UKI digest. One branch per format; only the format whose reference set is populated fires.

## Validation (`opa eval`)
| case | result |
|---|---|
| grub positive → grub policy | `executables=3` (no regression) |
| uki positive → uki policy | `boot_chain_ok=true`, `3` |
| digest mismatch | `33` (fail-closed) |
| grub evidence → uki policy | `33` (no cross-format hit) |
| uki evidence → grub policy | `33` (no cross-format hit) |

`opa check` shows only the pre-existing `query_reference_value` (AS runtime builtin) type notes, identical to before — zero new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)