### PR TITLE
Default boot_format to grub for any cloud (uki opt-in)

### DIFF
--- a/.github/workflows/build-cvm.yml
+++ b/.github/workflows/build-cvm.yml
@@ -40,7 +40,7 @@ on:
         options: [gcp, ali]
         default: gcp
       boot_format:
-        description: "boot format (auto = grub for gcp, uki for ali)"
+        description: "boot format (auto = grub; choose uki explicitly)"
         type: choice
         options: [auto, grub, uki]
         default: auto
@@ -70,9 +70,9 @@ jobs:
       OWNER: ${{ inputs.owner || vars.OWNER_ADDRESS }}
       PUBLISH: ${{ inputs.publish }}
       # cloud/boot-format dimensions (independent; a CVM = one CLOUD × one BOOT_FORMAT = one measurement
-      # chain). cloud defaults to gcp; boot_format auto -> grub for gcp / uki for ali.
+      # chain). cloud defaults to gcp; boot_format auto -> grub (uki is opt-in, any cloud).
       CLOUD: ${{ inputs.cloud || 'gcp' }}
-      # boot_format 'auto'/'' -> empty, so build-tapp derives it from cloud (gcp->grub, ali->uki)
+      # boot_format 'auto'/'' -> empty, so build-tapp applies its default (grub)
       BOOT_FORMAT: ${{ (inputs.boot_format == 'auto' || inputs.boot_format == '') && '' || inputs.boot_format }}
       KBS_URLS: ${{ vars.TAPP_KBS_URLS }}                       # required (no safe default)
       GCP_PROJECT: ${{ vars.GCP_PROJECT || 'g-devops' }}

--- a/cvm/README.md
+++ b/cvm/README.md
@@ -8,7 +8,7 @@ One CVM = one point in this grid; each combination has its own image, its own re
 | Dimension | Values | Set by | Effect |
 |---|---|---|---|
 | **cloud** | `gcp` \| `ali` | `CLOUD` | kernel + guest agent + publish target (see platform table) |
-| **boot_format** | `grub` \| `uki` | `BOOT_FORMAT` (default: gcp→`grub`, ali→`uki`) | boot chain ⇒ **shape of the measurement** (see below) |
+| **boot_format** | `grub` \| `uki` | `BOOT_FORMAT` (default `grub` for any cloud; `uki` is opt-in) | boot chain ⇒ **shape of the measurement** (see below) |
 | **env** | `dev` (HARDEN=0) \| `prod` (HARDEN=1) | `HARDEN` | dev keeps cloud-init/SSH for debugging; prod purges it |
 | **owner** | `0x…` address | `OWNER_ADDRESS` | baked into `config.toml` → folded into the **initrd measurement** (an attested dimension) |
 | **version** | tapp-server release tag | `TAPP_SERVER_URL` | which tapp-server binary + image-name suffix |
@@ -20,10 +20,10 @@ One CVM = one point in this grid; each combination has its own image, its own re
 ### Platform differences (everything else is shared)
 | | GCP (`gcp`) | Alibaba Cloud (`ali`) |
 |---|---|---|
-| default boot format | grub | uki (systemd-boot) |
+| default boot format | grub | grub (`uki` opt-in via `BOOT_FORMAT=uki`) |
 | kernel | `linux-image-gcp` (+ fix A: point `/boot/vmlinuz`) | base **generic** kernel (ECS uses virtio; no swap) |
 | guest / dev SSH inject | `google-guest-agent` | cloud-init pinned to `datasource_list: [ AliYun ]` |
-| convert boot handling | ESP grub.cfg sync (`cryptpilot-convert`, #130) | `cryptpilot-convert --uki` (needs dracut + systemd-boot-efi) |
+| convert boot handling | grub → ESP grub.cfg sync (`cryptpilot-convert`, #130) | grub → ESP sync; `uki` → `cryptpilot-convert --uki` (dracut + systemd-boot-efi) |
 | publish | `publish-gcp-image.sh` → GCS + `gcloud compute images create` | `publish-ali-image.sh` → OSS + `aliyun ecs ImportImage` |
 
 ## Directory contents

--- a/cvm/build-tapp.sh
+++ b/cvm/build-tapp.sh
@@ -42,11 +42,11 @@ SYSBOX_DEB_URL="${SYSBOX_DEB_URL:-https://downloads.nestybox.com/sysbox/releases
 # Two independent build dimensions (each image = one of each):
 #   CLOUD       gcp | ali  — kernel/guest/publish. gcp: linux-image-gcp + fix A + google-guest-agent +
 #               publish-gcp-image.sh; ali: generic kernel + cloud-init(AliYun) + publish-ali-image.sh.
-#   BOOT_FORMAT grub | uki — boot format (stage B convert). Defaults by cloud (gcp->grub, ali->uki),
-#               overridable. Determines --uki + UKI prereqs + the reference-value shape (grub 5 / uki 1).
+#   BOOT_FORMAT grub | uki — boot format (stage B convert). Defaults to grub for any cloud;
+#               set uki explicitly. Determines --uki + UKI prereqs + the reference-value shape (grub 5 / uki 1).
 # Both exported so prepare-*.sh (stage B) inherits them.
 export CLOUD="${CLOUD:-gcp}"
-export BOOT_FORMAT="${BOOT_FORMAT:-$([ "$CLOUD" = gcp ] && echo grub || echo uki)}"
+export BOOT_FORMAT="${BOOT_FORMAT:-grub}"
 # passed through to prepare-tapp.sh (used by convert)
 export CONFIG_DIR="${CONFIG_DIR:-$HERE/config_dir}"
 export FDE_PACKAGE="${FDE_PACKAGE:-$HERE/cryptpilot-fde-guest_0.8.0_amd64.deb}"   # 0.8.0 in-image runtime (cryptpilot-fde split into -host/-guest at 0.8.0)

--- a/cvm/prepare-tapp.sh
+++ b/cvm/prepare-tapp.sh
@@ -23,9 +23,9 @@ set -euo pipefail
 #   BOOT_FORMAT grub | uki — boot format. grub: traditional shim/grub (convert #130 syncs the ESP
 #               grub.cfg); uki: systemd-boot / Unified Kernel Image (convert --uki; needs dracut +
 #               systemd-boot-efi). Reference value differs: grub -> 5 components, uki -> 1 (measurement.uki).
-# Default BOOT_FORMAT by cloud (gcp->grub, ali->uki) but OVERRIDABLE (e.g. a uki image on gcp).
+# Default BOOT_FORMAT = grub for any cloud; set uki explicitly (e.g. a uki image on ali).
 CLOUD="${CLOUD:-gcp}"
-BOOT_FORMAT="${BOOT_FORMAT:-$([ "$CLOUD" = gcp ] && echo grub || echo uki)}"
+BOOT_FORMAT="${BOOT_FORMAT:-grub}"
 CONFIG_DIR="${CONFIG_DIR:-./config_dir}"
 FDE_PACKAGE="${FDE_PACKAGE:-cryptpilot-fde_0.7.0_amd64.deb}"
 ROOTFS_MODE="${ROOTFS_MODE:---rootfs-no-encryption}"   # or "--rootfs-passphrase <pass>"


### PR DESCRIPTION
Per feedback: `boot_format=auto` should **not** vary by cloud. Drop the per-cloud derivation (`gcp→grub`, `ali→uki`); `auto` now resolves to **grub for any cloud**, and **uki is an explicit opt-in** (`BOOT_FORMAT=uki` / dispatch `boot_format=uki`).

- `build-tapp.sh` / `prepare-tapp.sh`: `BOOT_FORMAT` default → `grub` (was cloud-conditional).
- `build-cvm.yml`: input description + env comments updated.
- `README.md`: dimension + platform tables updated.

boot_format stays a real independent axis — this just makes the default uniform. The uki build/convert/reference/policy paths are unchanged; you still get a uki image (any cloud) by choosing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)