### PR TITLE
Add opt-in OVERWRITE for image publish

### DIFF
--- a/.github/workflows/build-cvm.yml
+++ b/.github/workflows/build-cvm.yml
@@ -44,6 +44,10 @@ on:
         type: choice
         options: [grub, uki]
         default: grub
+      overwrite:
+        description: "replace an existing image of the same name (delete + recreate). Off = fail if it exists."
+        type: boolean
+        default: false
 
 concurrency:
   group: build-cvm-${{ inputs.cloud || 'gcp' }}-${{ inputs.version }}-${{ inputs.owner || vars.OWNER_ADDRESS }}
@@ -155,6 +159,7 @@ jobs:
           OWNER_TAG="$(printf '%s' "$OWNER" | tr 'A-Z' 'a-z')"
           IMG="${{ steps.v.outputs.imgbase }}-${VERSION//./-}-${OWNER_TAG}"
           IMAGE_FAMILY="${{ steps.v.outputs.imgbase }}-${OWNER_TAG}" \
+          OVERWRITE=${{ inputs.overwrite && '1' || '0' }} \
             ./publish-gcp-image.sh "out-${{ matrix.env }}.qcow2" "$IMG"
 
       - name: Stage C — publish versioned image (ali)
@@ -165,6 +170,7 @@ jobs:
           OWNER_TAG="$(printf '%s' "$OWNER" | tr 'A-Z' 'a-z')"
           IMG="${{ steps.v.outputs.imgbase }}-${VERSION//./-}-${OWNER_TAG}"
           ALIYUN_REGION="$ALIYUN_REGION" OSS_BUCKET="$OSS_BUCKET" \
+          OVERWRITE=${{ inputs.overwrite && '1' || '0' }} \
             ./publish-ali-image.sh "out-${{ matrix.env }}.qcow2" "$IMG"
 
       - name: Reference values — compute, write, register on AS

--- a/cvm/publish-ali-image.sh
+++ b/cvm/publish-ali-image.sh
@@ -34,16 +34,25 @@ OSS_ENDPOINT="${OSS_ENDPOINT:-oss-${ALIYUN_REGION}.aliyuncs.com}"
 PLATFORM="${PLATFORM:-Ubuntu}"
 KEEP_OSS_OBJECT="${KEEP_OSS_OBJECT:-0}"                   # 1 = keep the uploaded qcow2 in OSS after import
 POLL_MAX="${POLL_MAX:-1800}"                              # max seconds to wait for the image to become Available
+OVERWRITE="${OVERWRITE:-0}"                              # 1 = if the image name exists, delete then recreate
 # ====================
 
 for t in ossutil aliyun python3; do command -v "$t" >/dev/null || { echo "missing tool: $t" >&2; exit 1; }; done
 
-# refuse to clobber an existing image name (give a clear hint up front)
-if aliyun ecs DescribeImages --RegionId "$ALIYUN_REGION" --ImageName "$NAME" 2>/dev/null \
-     | python3 -c 'import sys,json; sys.exit(0 if json.load(sys.stdin).get("TotalCount",0)>0 else 1)'; then
-  echo "Ali image '$NAME' already exists in region $ALIYUN_REGION." >&2
-  echo "  delete it first, or publish under a new name (a different <ali-image-name>)." >&2
-  exit 1
+# An existing image name is immutable by default (a published version image may back running
+# instances; silently replacing it would change its measurements and break their attestation).
+# OVERWRITE=1 opts into delete-then-recreate for deliberate re-runs of the same version.
+EXIST_ID="$(aliyun ecs DescribeImages --RegionId "$ALIYUN_REGION" --ImageName "$NAME" 2>/dev/null \
+  | python3 -c 'import sys,json; im=json.load(sys.stdin).get("Images",{}).get("Image",[]); print(im[0]["ImageId"] if im else "")')"
+if [ -n "$EXIST_ID" ]; then
+  if [ "$OVERWRITE" = 1 ]; then
+    echo "==> image '$NAME' already exists ($EXIST_ID); OVERWRITE=1 → deleting it first"
+    aliyun ecs DeleteImage --RegionId "$ALIYUN_REGION" --ImageId "$EXIST_ID" --Force true >/dev/null
+  else
+    echo "Ali image '$NAME' already exists in region $ALIYUN_REGION ($EXIST_ID)." >&2
+    echo "  re-run with OVERWRITE=1 to replace it, delete it manually, or publish under a new name." >&2
+    exit 1
+  fi
 fi
 
 echo "==> [C1] ossutil cp -> oss://$OSS_BUCKET/$OSS_OBJECT"

--- a/cvm/publish-gcp-image.sh
+++ b/cvm/publish-gcp-image.sh
@@ -33,6 +33,7 @@ GCP_PROJECT="${GCP_PROJECT:-g-devops}"
 GUEST_OS_FEATURES="${GUEST_OS_FEATURES:-UEFI_COMPATIBLE,GVNIC,SEV_CAPABLE,TDX_CAPABLE}"
 WORKDIR="${WORKDIR:-$(cd "$(dirname "$IMG")" && pwd)}"   # where disk.raw / tarball are staged
 KEEP_TARBALL="${KEEP_TARBALL:-0}"                         # 1 = keep the local .tar.gz after upload
+OVERWRITE="${OVERWRITE:-0}"                              # 1 = if the image name exists, delete then recreate
 # ====================
 
 for t in qemu-img tar gsutil gcloud; do command -v "$t" >/dev/null || { echo "missing tool: $t" >&2; exit 1; }; done
@@ -40,12 +41,19 @@ for t in qemu-img tar gsutil gcloud; do command -v "$t" >/dev/null || { echo "mi
 RAW="$WORKDIR/disk.raw"
 TAR="$WORKDIR/$NAME.tar.gz"
 
-# refuse to clobber an existing image name (gcloud would error anyway; give a clearer hint up front)
+# An existing image name is immutable by default (a published version image may back running
+# instances; silently replacing it would change its measurements and break their attestation).
+# OVERWRITE=1 opts into delete-then-recreate for deliberate re-runs of the same version.
 if gcloud compute images describe "$NAME" --project="$GCP_PROJECT" >/dev/null 2>&1; then
-  echo "GCP image '$NAME' already exists in project $GCP_PROJECT." >&2
-  echo "  delete it first:  gcloud compute images delete $NAME --project=$GCP_PROJECT" >&2
-  echo "  or publish under a new name (e.g. ${NAME}-$(date +%Y%m%d) — pass a different <gcp-image-name>)." >&2
-  exit 1
+  if [ "$OVERWRITE" = 1 ]; then
+    echo "==> image '$NAME' already exists; OVERWRITE=1 → deleting it first"
+    gcloud compute images delete "$NAME" --project="$GCP_PROJECT" --quiet
+  else
+    echo "GCP image '$NAME' already exists in project $GCP_PROJECT." >&2
+    echo "  re-run with OVERWRITE=1 to replace it, delete it manually, or publish under a new name." >&2
+    echo "  delete:  gcloud compute images delete $NAME --project=$GCP_PROJECT" >&2
+    exit 1
+  fi
 fi
 
 cleanup() { rm -f "$RAW"; [ "$KEEP_TARBALL" = 1 ] || rm -f "$TAR"; }


### PR DESCRIPTION
The `gcp+uki` re-run failed at Stage C because `og-tdx-dev-v0-2-0-<owner>` already existed and publish refuses to clobber — so it never reached the UKI reference-registration step.

**Design**: version images stay **immutable by default** (a published image may back running confidential instances; silently replacing it changes measurements → breaks their attestation). Add an **opt-in** `OVERWRITE` instead of flipping the default:
- `publish-gcp-image.sh`: `OVERWRITE=1` → `gcloud compute images delete` then recreate.
- `publish-ali-image.sh`: `OVERWRITE=1` → resolve the existing `ImageId` and `DeleteImage --Force` then recreate.
- `build-cvm.yml`: new `overwrite` dispatch input (boolean, default false) → passed as `OVERWRITE` to both Stage C steps.

Re-running the same version with `overwrite=true` now deletes-and-recreates instead of failing. The reference-values step already overwrites its AS policy by id, so this makes the image path consistent with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)