### PR TITLE
Revert DISK_SIZE (ineffective under rw_overlay=ram)

### DIFF
--- a/.github/workflows/build-cvm.yml
+++ b/.github/workflows/build-cvm.yml
@@ -52,10 +52,6 @@ on:
         description: "replace an existing image of the same name (delete + recreate). Off = fail if it exists."
         type: boolean
         default: false
-      disk_size:
-        description: "boot-disk size of the image (e.g. 20G, 40G). Only grows; the verity rootfs sizes to it."
-        required: false
-        default: "20G"
 
 concurrency:
   group: build-cvm-${{ inputs.cloud || 'gcp' }}-${{ inputs.boot_format }}-${{ inputs.version }}-${{ inputs.owner || vars.OWNER_ADDRESS }}
@@ -124,7 +120,7 @@ jobs:
         run: |
           cd cvm
           HARDEN=${{ steps.v.outputs.harden }} ENABLE_SYSBOX=1 \
-            OWNER_ADDRESS="$OWNER" KBS_URLS="$KBS_URLS" DISK_SIZE="${{ inputs.disk_size || '20G' }}" \
+            OWNER_ADDRESS="$OWNER" KBS_URLS="$KBS_URLS" \
             TAPP_SERVER_URL="https://github.com/0gfoundation/0g-tapp/releases/download/${VERSION}/tapp-server" \
             ./build-tapp.sh base-noble.qcow2 "out-${{ matrix.env }}.qcow2"
 

--- a/cvm/README.md
+++ b/cvm/README.md
@@ -86,7 +86,6 @@ KBS_URLS='"http://<kbs-host-1>:9091", "http://<kbs-host-2>:9091"' \
 - tapp-server is downloaded by default from GitHub v0.1.0 (includes the guest-components `8d71a3b4` fix, RTMR OK); if you have it locally, set `TAPP_SERVER_BIN=<path>`.
 - Storage / Sysbox knobs: `DATA_ROOT` (docker data-root, default `/data/docker`), `CONTAINERD_ROOT` (default `/data/containerd`), `DOCKER_VERSION` (default `5:27.5.1-…noble`; empty = repo default), `ENABLE_SYSBOX` / `SYSBOX_VERSION` (default `0.7.0`).
 - Publish (Stage C, opt-in): `PUBLISH_AS=<gcp-image-name>` publishes the built image to GCP after the build (see [Publish to GCP](#publish-to-gcp-stage-c)); `GCS_BUCKET` / `GCP_PROJECT` / `GUEST_OS_FEATURES` pass through.
-- `DISK_SIZE` — boot-disk size of the produced image (default `20G` = the cached base). A larger value grows the working copy (`qemu-img resize` + `growpart` + `resize2fs`) before the build; only grows (shrinking is ignored). The read-only verity rootfs sizes to this.
 - Other environment variables: `DNS_FALLBACK` `PURGE_KERNEL` `CONFIG_DIR` `FDE_PACKAGE` `ROOTFS_MODE` `IN_PLACE` `INSTALL_KERNEL` `NBD_RESET` (see the top of the script).
 
 ## Persistent data disk (`/data`) — always configured

--- a/cvm/build-tapp.sh
+++ b/cvm/build-tapp.sh
@@ -47,10 +47,6 @@ SYSBOX_DEB_URL="${SYSBOX_DEB_URL:-https://downloads.nestybox.com/sysbox/releases
 # Both exported so prepare-*.sh (stage B) inherits them.
 export CLOUD="${CLOUD:-gcp}"
 export BOOT_FORMAT="${BOOT_FORMAT:-grub}"
-# Boot-disk size of the produced image (the read-only verity rootfs sizes to this). Default 20G =
-# the cached base. A larger value grows the working copy (qemu-img resize + growpart + resize2fs)
-# up front, before the build; shrinking below the current size is unsupported (ignored).
-DISK_SIZE="${DISK_SIZE:-20G}"
 # passed through to prepare-tapp.sh (used by convert)
 export CONFIG_DIR="${CONFIG_DIR:-$HERE/config_dir}"
 export FDE_PACKAGE="${FDE_PACKAGE:-$HERE/cryptpilot-fde-guest_0.8.0_amd64.deb}"   # 0.8.0 in-image runtime (cryptpilot-fde split into -host/-guest at 0.8.0)
@@ -71,21 +67,6 @@ OUT="${2:?usage: $0 <ubuntu-24.04-base.qcow2> <output.qcow2>}"
 [ -f "$HERE/prepare-tapp.sh" ] || { echo "missing prepare-tapp.sh (must be in the same directory as this script)" >&2; exit 1; }
 [ -d "$CONFIG_DIR" ] || { echo "CONFIG_DIR not found: $CONFIG_DIR" >&2; exit 1; }
 [ -f "$FDE_PACKAGE" ] || { echo "FDE_PACKAGE not found: $FDE_PACKAGE" >&2; exit 1; }
-
-# ---- resize the working image up front (before Stage A / convert) ----
-# The final image's read-only verity rootfs is sized from the disk here, so grow the disk + rootfs
-# partition (sda1) + filesystem now. Preserve partition numbering (growpart, NOT virt-resize --expand,
-# which renumbers sda1->sda4 and breaks the sda1=rootfs / sda16=/boot assumptions). Only grows: a
-# DISK_SIZE at or below the current size is a no-op (shrinking a populated fs is unsafe).
-CUR_BYTES="$(qemu-img info --output=json "$IN" | python3 -c 'import sys,json; print(json.load(sys.stdin)["virtual-size"])')"
-WANT_BYTES="$(numfmt --from=iec "$DISK_SIZE")"
-if [ "$WANT_BYTES" -gt "$CUR_BYTES" ]; then
-  echo "==> resize disk -> $DISK_SIZE (grow sda1 + fs; was $(numfmt --to=iec "$CUR_BYTES"))"
-  qemu-img resize "$IN" "$DISK_SIZE"
-  virt-customize -a "$IN" --run-command 'growpart /dev/sda 1 && resize2fs /dev/sda1'
-elif [ "$WANT_BYTES" -lt "$CUR_BYTES" ]; then
-  echo "==> DISK_SIZE=$DISK_SIZE is below the current $(numfmt --to=iec "$CUR_BYTES"); shrinking unsupported — keeping current size" >&2
-fi
 
 TMPD="$(mktemp -d)"
 trap 'rm -rf "$TMPD"' EXIT


### PR DESCRIPTION
DISK_SIZE grew the input disk, but cryptpilot-convert shrinks the rootfs to actual data and the writable `/` overlay is RAM-backed (`rw_overlay=ram`) — so a bigger disk didn't change the usable rootfs (a 40G build still gave an ~18.7G RAM-bounded `/`). Remove the misleading knob; keep `image_name`. Revisit if we switch to `rw_overlay=disk`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)