### PR TITLE
feat(verify-app): claim_config owner reconcile + no-policy boot-chain output

### DIFF
--- a/.claude/skills/0g-tapp-cli/SKILL.md
+++ b/.claude/skills/0g-tapp-cli/SKILL.md
@@ -57,8 +57,10 @@ tapp-cli -s <server> -k 0x<key> get-service-logs -f <file> [-n 100] # tapp-serve
 tapp-cli -s <server> -k 0x<key> docker-logout                    # logout from Docker registry on this server
 ```
 
-### verify-app: boot-chain check (`--policy-ids`)
-- **`--policy-ids <id>` is what triggers the boot-chain check** (shim/grub/kernel/initrd/kernel_cmdline vs an image's reference values). **Without it**, the AS uses its default policy and **no `boot-chain` line is printed** — only `ear.status`/`tcb_status`.
+### verify-app: two independent reference axes
+- **`--contract`+`--rpc-url` = dynamic references** (on-chain): reconciles runtime events vs the registry → `reconcile : signer✓ compose✓ volumes✓ image✓ owner✓`. The **owner** check (v0.3.0+) compares the `claim_config` event's owner against the on-chain app owner (`✗` = hijacked/mismatched → Result ❌; `?` = no claim_config event, pre-0.3 image).
+- **`--policy-ids <id>` = static references** (AS boot-chain check: shim/grub/kernel/initrd/kernel_cmdline or uki vs the image's reference values).
+- **Whichever axis has NO reference, the measured values are printed verbatim**: no `--contract` → owner/compose/images as attested; no `--policy-ids` → boot-chain component digests in reference-value JSON (`{"measurement.<comp>.SHA-384": [...]}`), directly diffable against `verifier/reference-values/<cloud>/<boot_format>/<version>/<env>.json`.
 - Output line: `boot-chain : ✓ (executables=3, matches policy reference)` = matched; `✗ (executables=33, ...)` = did not match; `?` = policy set no executables claim. (`executables` is the AR4SI claim: **3** = approved boot chain, **33** = unrecognized.)
 - **`--as-endpoint <host:port>`** picks the Attestation Service (default `47.237.201.184:50004`, the shared AS). Point it at a self-hosted local AS (e.g. `127.0.0.1:50004`, see the `verifier/0g-tapp-verifier` submodule) to use RVPS-backed reference values.
 - **Policy ids** — two formats depending on build mode:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5550,6 +5550,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
  "sha3",
  "thiserror 1.0.69",
  "tokio",

--- a/README.md
+++ b/README.md
@@ -353,21 +353,32 @@ tapp-cli -s http://<any-tapp>:50051 -k 0x<deployer-key> withdraw \
 
 ### Verifying an App
 
-`tapp-cli verify-app` checks that what a node actually runs matches what is registered on-chain.
+`tapp-cli verify-app` checks that what a node actually runs matches its reference values.
+Two independent axes select which references are enforced:
 
-**Chain mode** (pass `--contract` + `--rpc-url`): reads the registry, fetches evidence from every node's on-chain `teeUrl`, verifies each TDX quote via the CoCo Attestation Service, and reconciles the evidence (signer, compose, volumes, image) against the chain.
+- **`--contract` + `--rpc-url` → dynamic references** (on-chain): reconciles the runtime
+  events against the registry — signer, compose, volumes, image, and **owner** (the
+  `claim_config` event's owner vs the on-chain app owner) → `signer✓ compose✓ volumes✓ image✓ owner✓`.
+- **`--policy-ids` → static references** (AS-registered boot-chain values): the AS enforces
+  the policy and returns the AR4SI executables claim → `boot-chain ✓ (executables=3)`.
+
+Whichever axis has NO reference supplied, verify-app prints that side's **measured values
+verbatim** so you can compare manually:
+- no `--contract` → prints owner / compose / images as attested;
+- no `--policy-ids` → prints the boot-chain component digests in reference-value JSON
+  (`{"measurement.<shim|grub|kernel|initrd|kernel_cmdline|uki>.SHA-384": [...]}`), directly
+  diffable against `verifier/reference-values/<cloud>/<boot_format>/<version>/<env>.json`.
 
 ```bash
+# full verification: dynamic (chain) + static (policy)
 tapp-cli verify-app \
   --app-id my-app \
   --rpc-url https://evmrpc-testnet.0g.ai \
-  --contract 0x<TappRegistry>
+  --contract 0x<TappRegistry> \
+  --policy-ids 0g-tapp-<cloud>-<boot_format>-<version>-<env>
   # --as-endpoint host:port   # CoCo-AS gRPC endpoint, default 47.237.201.184:50004
-```
 
-**Direct mode** (omit `--contract`, pass `-s <server>`): verifies a single node's evidence + quote and shows what it attests, without on-chain reconciliation — useful for apps not yet registered.
-
-```bash
+# direct mode (single node, not yet registered): prints attested values verbatim
 tapp-cli -s http://<tapp>:50051 verify-app --app-id my-app
 ```
 

--- a/docs/EVIDENCE_AND_AS_VERIFICATION.md
+++ b/docs/EVIDENCE_AND_AS_VERIFICATION.md
@@ -235,6 +235,11 @@ tapp.0g.com claim_config {"owner":"0x<owner>","chain_rpc_url":"…",
 claim 事件由启动后的首次认领产生(ClaimConfig RPC 的动态模式,或 config.toml 预制模式启动自动认领),
 每次 VM 重启 RTMR 清零、重新认领、重新度量——owner 与 quote 始终同生命周期。
 
+**`tapp-cli verify-app` 已自动执行本节规则**(v0.3.0+):chain 模式下 reconcile 行输出
+`owner✓/✗/?`(✓=claim_config owner==链上 owner;✗=不一致,Result ❌;?=无 claim_config 事件,
+0.3 之前的镜像)。另外无 `--policy-ids` 时,boot-chain 组件度量按参考值 JSON 格式原样打印,
+可直接与 `verifier/reference-values/…/<env>.json` diff。
+
 ---
 
 ## 实测走查：`0g-agentic-id-attestor`（严格照本文档端到端跑过）

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1065,9 +1065,11 @@ impl TappService for TappServiceImpl {
             kbs_node_urls: req.kbs_node_urls.clone(),
         };
 
-        // Dynamically initialize KMS client if kbs_node_urls provided and not
-        // already configured (config.toml had no [kbs] section — dynamic mode).
-        if !req.kbs_node_urls.is_empty() && self.kms_client.read().await.is_none() {
+        // Initialize or replace KMS client with the claimed kbs_node_urls.
+        // Always overwrite: config.toml may have [kbs] with empty node_urls=[],
+        // which creates a KmsClient stub that would fail on every request. Replace
+        // whenever the claim provides non-empty urls.
+        if !req.kbs_node_urls.is_empty() {
             info!(
                 nodes = req.kbs_node_urls.len(),
                 "Initializing KMS client from ClaimConfig"

--- a/tapp-cli/src/main.rs
+++ b/tapp-cli/src/main.rs
@@ -1338,6 +1338,28 @@ fn boot_chain_line(executables: Option<i64>, show: bool) -> Option<String> {
     })
 }
 
+/// Print boot-chain component digests as reference-value JSON (same shape as
+/// verifier/reference-values/.../<env>.json) so the output can be diffed/copied.
+fn print_boot_measurements(measurements: &[(String, String)], indent: &str) {
+    let mut grouped: serde_json::Map<String, serde_json::Value> = Default::default();
+    for (component, hash) in measurements {
+        let key = format!("measurement.{}.SHA-384", component);
+        let arr = grouped.entry(key).or_insert_with(|| serde_json::json!([]));
+        if let Some(a) = arr.as_array_mut() {
+            let v = serde_json::json!(hash);
+            if !a.contains(&v) {
+                a.push(v);
+            }
+        }
+    }
+    println!("{}boot-chain (no policy — reference-value format):", indent);
+    let json =
+        serde_json::to_string_pretty(&serde_json::Value::Object(grouped)).unwrap_or_default();
+    for line in json.lines() {
+        println!("{}  {}", indent, line);
+    }
+}
+
 async fn verify_app_cmd(
     server: &str,
     app_id: &str,
@@ -1357,8 +1379,15 @@ async fn verify_app_cmd(
         println!("  server      : {}", d.server);
         println!("  signer      : {}  (attested in report_data)", d.signer);
         println!("  AS          : ear.status={} tcb_status={} advisories={}", d.ear_status, d.tcb_status, d.advisories);
-        if let Some(l) = boot_chain_line(d.boot_executables, show_boot) {
-            println!("  {}", l);
+        if show_boot {
+            if let Some(l) = boot_chain_line(d.boot_executables, show_boot) {
+                println!("  {}", l);
+            }
+        } else if !d.boot_measurements.is_empty() {
+            print_boot_measurements(&d.boot_measurements, "  ");
+        }
+        if let Some(owner) = &d.claimed_owner {
+            println!("  owner       : {}  (from claim_config event; no chain comparison in direct mode)", owner);
         }
         if !d.compose_hash.is_empty() {
             println!("  compose     : {}", d.compose_hash);
@@ -1397,12 +1426,29 @@ async fn verify_app_cmd(
             "    AS         : ear.status={} tcb_status={} advisories={}",
             n.ear_status, n.tcb_status, n.advisories
         );
+        let owner_str = match &n.owner_claim {
+            Some(Ok(_))  => "✓",
+            Some(Err(_)) => "✗",
+            None         => "?",
+        };
         println!(
-            "    reconcile  : signer{} compose{} volumes{} image{}",
-            yn(n.signer_ok), yn(n.compose_ok), yn(n.volumes_ok), yn(n.image_ok)
+            "    reconcile  : signer{} compose{} volumes{} image{} owner{}",
+            yn(n.signer_ok), yn(n.compose_ok), yn(n.volumes_ok), yn(n.image_ok), owner_str
         );
-        if let Some(l) = boot_chain_line(n.boot_executables, show_boot) {
-            println!("    {}", l);
+        if let Some(Err(claimed)) = &n.owner_claim {
+            println!("    owner      : ✗ claim_config says {} but on-chain owner differs", claimed);
+            all_ok = false;
+        } else if let Some(Ok(claimed)) = &n.owner_claim {
+            println!("    owner      : ✓ {}", claimed);
+        } else {
+            println!("    owner      : ? no claim_config event in eventlog");
+        }
+        if show_boot {
+            if let Some(l) = boot_chain_line(n.boot_executables, show_boot) {
+                println!("    {}", l);
+            }
+        } else if !n.boot_measurements.is_empty() {
+            print_boot_measurements(&n.boot_measurements, "    ");
         }
         if !n.note.is_empty() {
             println!("    note       : {}", n.note);

--- a/tapp-common/Cargo.toml
+++ b/tapp-common/Cargo.toml
@@ -26,6 +26,7 @@ serde_yaml = "0.9"
 base64 = "0.22"
 
 # Cryptography
+sha2 = "0.10"
 sha3 = "0.10"
 hex = "0.4"
 k256 = { version = "0.13", features = ["ecdsa", "std"] }

--- a/tapp-common/src/verify.rs
+++ b/tapp-common/src/verify.rs
@@ -31,6 +31,13 @@ pub struct NodeVerdict {
     pub volumes_ok: bool,
     pub image_ok: bool,
     pub boot_executables: Option<i64>, // AR4SI executables claim (3 = boot chain matched policy)
+    /// Boot-chain component digests from the eventlog (printed when no policy selected).
+    pub boot_measurements: Vec<(String, String)>,
+    /// claim_config owner from event log:
+    ///   Some(Ok(addr))  = found and matches on-chain app owner
+    ///   Some(Err(addr)) = found but mismatches (addr is what the event says)
+    ///   None            = no claim_config event found in event log
+    pub owner_claim: Option<Result<String, String>>,
     pub note: String,
 }
 
@@ -145,6 +152,140 @@ fn latest_successful_start(cc_eventlog_b64: &str, app_id: &str) -> Result<Option
     Ok(last)
 }
 
+/// ASCII view of (possibly UTF-16LE) event data: drop NULs, lowercase.
+fn event_data_ascii(data: &[u8]) -> String {
+    data.iter()
+        .filter(|&&b| b != 0)
+        .map(|&b| (b as char).to_ascii_lowercase())
+        .collect()
+}
+
+/// Parse the cc_eventlog and return the boot-chain component digests that AS
+/// policies compare against reference values — the SAME selection rules as
+/// verifier/policy.rego:
+///   shim           EV_EFI_BOOT_SERVICES_APPLICATION, device_path ~ shimx64.efi
+///   grub           EV_EFI_BOOT_SERVICES_APPLICATION, device_path ~ grubx64.efi
+///   uki            EV_EFI_BOOT_SERVICES_APPLICATION, device_path ~ bootx64.efi (UKI boot)
+///   kernel         EV_IPL, string contains vmlinuz
+///   initrd         EV_IPL, string contains initrd
+///   kernel_cmdline EV_IPL, string starts with "kernel_cmdline:"
+/// Returns (component, sha384_hex) pairs in eventlog order.
+fn extract_boot_measurements(cc_eventlog_b64: &str) -> Result<Vec<(String, String)>> {
+    const EV_IPL: usize = 0xd;
+    const EV_EFI_BSA: usize = 0x8000_0003;
+
+    let log = B64.decode(cc_eventlog_b64).map_err(|e| anyhow!("eventlog b64: {}", e))?;
+    let u32le = |b: &[u8]| u32::from_le_bytes([b[0], b[1], b[2], b[3]]) as usize;
+
+    // skip SpecID event
+    let mut o = 8 + 20;
+    if o + 4 > log.len() { return Ok(vec![]); }
+    let ds = u32le(&log[o..o + 4]);
+    o += 4 + ds;
+
+    let mut results: Vec<(String, String)> = Vec::new();
+
+    while o + 12 <= log.len() {
+        let _pcr = u32le(&log[o..o + 4]); o += 4;
+        let et = u32le(&log[o..o + 4]); o += 4;
+        let cnt = u32le(&log[o..o + 4]); o += 4;
+
+        let mut sha384: Option<String> = None;
+        for _ in 0..cnt {
+            if o + 2 > log.len() { return Ok(results); }
+            let alg = u16::from_le_bytes([log[o], log[o + 1]]);
+            let sz = alg_size(alg);
+            o += 2;
+            if alg == 0xc && o + sz <= log.len() {
+                sha384 = Some(hex::encode(&log[o..o + sz]));
+            }
+            o += sz;
+        }
+        if o + 4 > log.len() { break; }
+        let dl = u32le(&log[o..o + 4]); o += 4;
+        if o + dl > log.len() { break; }
+        let data = &log[o..o + dl];
+        o += dl;
+
+        let Some(h) = sha384 else { continue };
+        let text = event_data_ascii(data);
+
+        let component = match et {
+            EV_EFI_BSA => {
+                if text.contains("shimx64.efi") { Some("shim") }
+                else if text.contains("grubx64.efi") { Some("grub") }
+                else if text.contains("bootx64.efi") { Some("uki") }
+                else { None }
+            }
+            EV_IPL => {
+                if text.starts_with("kernel_cmdline:") { Some("kernel_cmdline") }
+                else if text.contains("vmlinuz") { Some("kernel") }
+                else if text.contains("initrd") { Some("initrd") }
+                else { None }
+            }
+            _ => None,
+        };
+        if let Some(c) = component {
+            results.push((c.to_string(), h));
+        }
+    }
+    Ok(results)
+}
+
+/// Parse the cc_eventlog and extract the claimed owner from `claim_config` events.
+/// Returns:
+///   Ok(Some(owner)) — all claim_config events agree, returns the (normalized) owner
+///   Ok(None)        — no claim_config events found
+///   Err(msg)        — events found but inconsistent owners
+fn eventlog_claim_config_owner(cc_eventlog_b64: &str) -> Result<Option<String>> {
+    let log = B64.decode(cc_eventlog_b64).map_err(|e| anyhow!("eventlog b64: {}", e))?;
+    let u32le = |b: &[u8]| u32::from_le_bytes([b[0], b[1], b[2], b[3]]) as usize;
+
+    let mut o = 8 + 20;
+    if o + 4 > log.len() { return Ok(None); }
+    let ds = u32le(&log[o..o + 4]);
+    o += 4 + ds;
+
+    let mut owners: Vec<String> = Vec::new();
+    while o + 12 <= log.len() {
+        o += 4;
+        let et = u32le(&log[o..o + 4]); o += 4;
+        let cnt = u32le(&log[o..o + 4]); o += 4;
+        for _ in 0..cnt {
+            if o + 2 > log.len() { return Ok(owners.into_iter().next()); }
+            let alg = u16::from_le_bytes([log[o], log[o + 1]]);
+            o += 2 + alg_size(alg);
+        }
+        if o + 4 > log.len() { break; }
+        let dl = u32le(&log[o..o + 4]); o += 4;
+        if o + dl > log.len() { break; }
+        let data = &log[o..o + dl]; o += dl;
+
+        if et == 0x6 && dl >= 8 {
+            let tsz = u32le(&data[4..8]);
+            if 8 + tsz <= data.len() {
+                if let Ok(text) = std::str::from_utf8(&data[8..8 + tsz]) {
+                    if let Some(payload) = text.strip_prefix("tapp.0g.com claim_config ") {
+                        if let Ok(v) = serde_json::from_str::<serde_json::Value>(payload) {
+                            if let Some(owner) = v["owner"].as_str() {
+                                owners.push(owner.to_lowercase());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if owners.is_empty() { return Ok(None); }
+    let first = owners[0].clone();
+    if owners.iter().all(|o| o == &first) {
+        Ok(Some(first))
+    } else {
+        Err(anyhow!("inconsistent claim_config owners: {:?}", owners))
+    }
+}
+
 fn json_str_map(v: &serde_json::Value) -> HashMap<String, String> {
     let mut m = HashMap::new();
     if let Some(obj) = v.as_object() {
@@ -169,6 +310,8 @@ pub struct AsVerdict {
     /// AR4SI executables trust claim (== EXECUTABLES_MATCHED when the boot chain matched
     /// the policy reference values); None if the policy set no executables / no policy applied.
     pub executables: Option<i64>,
+    /// Unused — boot measurements now come from eventlog parsing, not AS token.
+    pub boot_measurements: Vec<(String, String)>,
 }
 
 /// Submit evidence to CoCo-AS (gRPC). `policy_ids` selects the policy to enforce; pass an
@@ -213,7 +356,8 @@ async fn verify_with_as(
     let tdx = &cpu0["ear.veraison.annotated-evidence"]["tdx"];
     let tcb = tdx["tcb_status"].as_str().unwrap_or("unknown").to_string();
     let adv = tdx["advisory_ids"].as_array().map(|a| a.len()).unwrap_or(0);
-    Ok(AsVerdict { ear_status, tcb_status: tcb, advisories: adv, executables })
+
+    Ok(AsVerdict { ear_status, tcb_status: tcb, advisories: adv, executables, boot_measurements: vec![] })
 }
 
 async fn fetch_evidence(tee_url: &str, app_id: &str) -> Result<Vec<u8>> {
@@ -240,8 +384,12 @@ pub struct DirectVerdict {
     pub tcb_status: String,
     pub advisories: usize,
     pub boot_executables: Option<i64>, // AR4SI executables claim (3 = boot chain matched policy)
+    /// Boot-chain measurements from AS (printed when no policy selected).
+    pub boot_measurements: Vec<(String, String)>,
     pub compose_hash: String, // from latest successful start_app, if any
     pub images: Vec<String>,
+    /// Owner address from claim_config event (if present). No chain comparison in direct mode.
+    pub claimed_owner: Option<String>,
     pub note: String,
 }
 
@@ -258,8 +406,10 @@ pub async fn verify_node_direct(
         tcb_status: "-".to_string(),
         advisories: 0,
         boot_executables: None,
+        boot_measurements: Vec::new(),
         compose_hash: String::new(),
         images: Vec::new(),
+        claimed_owner: None,
         note: String::new(),
     };
 
@@ -280,6 +430,7 @@ pub async fn verify_node_direct(
             v.tcb_status = av.tcb_status;
             v.advisories = av.advisories;
             v.boot_executables = av.executables;
+            v.boot_measurements = av.boot_measurements;
         }
         Err(e) => v.note = format!("{}AS: {}", v.note, e),
     }
@@ -288,6 +439,18 @@ pub async fn verify_node_direct(
         v.compose_hash = m.compose_hash;
         v.images = m.image_hash.into_values().collect();
     }
+
+    // boot measurements from eventlog (not from AS — no policy needed)
+    if let Ok(measurements) = extract_boot_measurements(cc_b64) {
+        v.boot_measurements = measurements;
+    }
+
+    // claim_config owner — direct mode: print without chain comparison
+    match eventlog_claim_config_owner(cc_b64) {
+        Ok(owner) => v.claimed_owner = owner,
+        Err(e) => v.note = format!("{}claim_config: {}", v.note, e),
+    }
+
     Ok(v)
 }
 
@@ -308,6 +471,12 @@ pub async fn verify_app(
         .await?
         .into_iter()
         .collect();
+    // On-chain app owner (who registered the app via registerApp)
+    let onchain_owner = onchain::get_app_owner(rpc_url, contract, app_id)
+        .await
+        .ok()
+        .map(|a| format!("0x{:x}", a))
+        .unwrap_or_default();
 
     let mut nodes = Vec::new();
     for signer in signers {
@@ -323,6 +492,8 @@ pub async fn verify_app(
             volumes_ok: false,
             image_ok: false,
             boot_executables: None,
+            boot_measurements: Vec::new(),
+            owner_claim: None,
             note: String::new(),
         };
 
@@ -391,6 +562,24 @@ pub async fn verify_app(
             }
             Ok(None) => v.note = format!("{}no successful start_app in eventlog", v.note),
             Err(e) => v.note = format!("{}eventlog parse: {}", v.note, e),
+        }
+
+        // boot measurements from eventlog (shown by the CLI when no policy selected)
+        if let Ok(measurements) = extract_boot_measurements(cc_b64) {
+            v.boot_measurements = measurements;
+        }
+
+        // ④c reconcile claim_config owner vs on-chain app owner
+        match eventlog_claim_config_owner(cc_b64) {
+            Ok(Some(claimed)) => {
+                if onchain_owner.is_empty() || claimed == onchain_owner.to_lowercase() {
+                    v.owner_claim = Some(Ok(claimed));
+                } else {
+                    v.owner_claim = Some(Err(claimed));
+                }
+            }
+            Ok(None) => {} // no claim_config event — leave owner_claim as None
+            Err(e) => v.note = format!("{}claim_config: {}", v.note, e),
         }
 
         nodes.push(v);


### PR DESCRIPTION
Clean re-apply of the feat/runtime-owner-claim commits that missed the #58 squash-merge (supersedes #63).

- verify-app chain mode reconciles the claim_config event owner vs the on-chain app owner → `owner✓/✗/?`
- without `--policy-ids`, both modes print boot-chain component digests in reference-value JSON (same selection rules as policy.rego), directly diffable against `verifier/reference-values/.../<env>.json`
- fix: claim-config always overwrites kms_client when kbs_node_urls provided
- get-tapp-info shows runtime chain+kbs set via ClaimConfig
- docs/skill: two-axis verify model (chain=dynamic refs, policy=static refs)

Tested live against 34.41.71.159 (all four chain×policy combinations) + 27/27 unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)