### PR TITLE
chore(verifier): reference values gcp uki v0.3.0 dev

### DIFF
--- a/verifier/reference-values/gcp/uki/v0.3.0/dev.json
+++ b/verifier/reference-values/gcp/uki/v0.3.0/dev.json
@@ -1,0 +1,5 @@
+{
+  "measurement.uki.SHA-384": [
+    "65aea968996ad0edb11c86f5a4fde0e7be6b641ff2f51987a775e4be27cbe7a920aa1c0fde59db0219998a4dbef8632c"
+  ]
+}


### PR DESCRIPTION
Auto-generated by build-cvm (canonical mode) for gcp/uki v0.3.0/dev. Registered on AS as policy `0g-tapp-gcp-uki-v0.3.0-dev_cpu`.