### PR TITLE
chore(verifier): reference values ali uki v0.3.0 dev

### DIFF
--- a/verifier/reference-values/ali/uki/v0.3.0/dev.json
+++ b/verifier/reference-values/ali/uki/v0.3.0/dev.json
@@ -1,0 +1,5 @@
+{
+  "measurement.uki.SHA-384": [
+    "d747b4352c8089f21201063ff8889506ea136d929e2a1a132a575434d8fee1f7fcb17f176da84bde5782b7f878301f83"
+  ]
+}


### PR DESCRIPTION
Auto-generated by build-cvm (canonical mode) for ali/uki v0.3.0/dev. Registered on AS as policy `0g-tapp-ali-uki-v0.3.0-dev_cpu`.