### PR TITLE
chore(verifier): reference values gcp uki v0.3.0 dev

### DIFF
--- a/verifier/reference-values/gcp/uki/v0.3.0/dev.json
+++ b/verifier/reference-values/gcp/uki/v0.3.0/dev.json
@@ -1,5 +1,5 @@
 {
   "measurement.uki.SHA-384": [
-    "65aea968996ad0edb11c86f5a4fde0e7be6b641ff2f51987a775e4be27cbe7a920aa1c0fde59db0219998a4dbef8632c"
+    "baaf1733c98b93d078cb709c5c5b76c69017ff4c6bec2c735ded7f402645e3dfa1de139c27f836b7fa43115c3c7471b7"
   ]
 }


### PR DESCRIPTION
Auto-generated by build-cvm (canonical mode) for gcp/uki v0.3.0/dev. Registered on AS as policy `0g-tapp-gcp-uki-v0.3.0-dev_cpu`.