### PR TITLE
fix(cvm): never let a built image update or restart itself (#71)

### DIFF
--- a/.github/workflows/build-cvm.yml
+++ b/.github/workflows/build-cvm.yml
@@ -177,6 +177,13 @@ jobs:
             TAPP_SERVER_URL="https://github.com/0gfoundation/0g-tapp/releases/download/${VERSION}/tapp-server" \
             ./build-tapp.sh base-noble.qcow2 "out-${{ matrix.env }}.qcow2"
 
+      - name: Verify the image cannot update or restart itself (issue #71)
+        # HARD GATE (unlike the boot smoke test below): offline guestfish check on the final
+        # converted image — apt-daily* masked, unattended-upgrades purged, needrestart list-only.
+        # An image that can auto-upgrade rotates the tapp signer (stale on-chain nodes) and
+        # changes RTMR/cmdline (dead reference values) days after this build; catch it here.
+        run: cvm/ci/check-no-auto-update.sh "cvm/out-${{ matrix.env }}.qcow2"
+
       # Boot smoke test intentionally NOT run here: this builder has no /dev/kvm, so under TCG the
       # 600s window is truncated before multi-user (false negatives) and it never gated (advisory).
       # cvm/test/boot-smoke-test.sh is kept for local / KVM-capable runs; make it a hard gate once a

--- a/cvm/README.md
+++ b/cvm/README.md
@@ -183,13 +183,15 @@ Defaults `OSS_BUCKET=0g-confidential-disk` (`ALIYUN_REGION` required, no default
 ## Security hardening (integrated in build stage A, see doc §11)
 purge: openssh-server / cloud-init / snapd / google-guest-agent / google-compute-engine (+oslogin) / google-osconfig-agent / google-cloud-ops-agent / open-vm-tools / pollinate / landscape-common; mask the serial/local getty; switch netplan to MAC-independent DHCP.
 
-### No self-updating, both variants (issue #71) — applied unconditionally, dev images too
-A measured image must only change when an operator changes it, so stage A always:
+### No unattended apt changes, both variants (issue #71) — applied unconditionally, dev images too
+Stage A always:
 - purges `unattended-upgrades` and **masks** `apt-daily{,-upgrade}.{timer,service}` (masking the timers matters on its own: they ship with `apt`, not with unattended-upgrades);
 - zeroes every `APT::Periodic::*` knob in `/etc/apt/apt.conf.d/20auto-upgrades`;
-- sets needrestart to **list-only** (`$nrconf{restart} = 'l'`), so even a manual `apt install` never restarts a service by itself.
+- sets needrestart to **list-only** (`$nrconf{restart} = 'l'`, drop-in `99-tapp-no-auto-restart.conf` — the name must sort **last**, needrestart reads `conf.d/*.conf` sorted and the last assignment wins), so even a manual `apt install` never restarts a service by itself.
 
-Why it is a build-time hard gate (`cvm/ci/check-no-auto-update.sh`, run on the final image in `build-cvm.yml`): an auto-upgrade restarts tapp-server → the in-memory app signer is re-derived → every on-chain node/service of every app on that node silently goes stale; and an auto kernel/initrd upgrade changes RTMR + `kernel_cmdline` → the image's whole reference-value set is invalidated. Both surface days later, far from the build. Package updates go through a rebuild (which regenerates reference values), never through the running node.
+Why it is a build-time hard gate (`cvm/ci/check-no-auto-update.sh`, run on the final image in `build-cvm.yml`): an auto-upgrade restarts tapp-server — observed on testnet as a glibc upgrade restarting `tapp-server` + `containerd` + `sysbox` in one go — and tapp derives the app signer in memory, so **within that same boot** every on-chain node/service of every app on the node silently goes stale. (On an image variant whose `/boot`/ESP is writable at runtime, an auto kernel upgrade would additionally change RTMR + `kernel_cmdline` and invalidate the reference values; here the rootfs overlay is RAM-backed, so that one is the secondary concern.) Package updates go through a rebuild, which regenerates reference values, never through the running node.
+
+Scope: this covers **apt**. `HARDEN=1` additionally purges the other self-changing components (`snapd` auto-refresh, `ubuntu-pro-client`'s `ua-timer`/`apt-news`/`esm-cache`, `motd-news`); on a `HARDEN=0` dev image those are still present.
 
 ## Verification (passed)
 - Image static checks: all the above packages gone, getty masked, netplan = 01-dhcp, resolv.conf 3 lines, gcp initrd cryptpilot = 16.

--- a/cvm/README.md
+++ b/cvm/README.md
@@ -181,7 +181,15 @@ Defaults `OSS_BUCKET=0g-confidential-disk` (`ALIYUN_REGION` required, no default
 - Also: DNS must be written to a static `/etc/resolv.conf` with **guestfish** (virt-customize wipes what it writes itself); reset nbd before convert with `modprobe nbd max_part=16`.
 
 ## Security hardening (integrated in build stage A, see doc §11)
-purge: openssh-server / cloud-init / snapd / google-guest-agent / google-compute-engine (+oslogin) / google-osconfig-agent / google-cloud-ops-agent / open-vm-tools / unattended-upgrades / pollinate / landscape-common; mask the serial/local getty; switch netplan to MAC-independent DHCP.
+purge: openssh-server / cloud-init / snapd / google-guest-agent / google-compute-engine (+oslogin) / google-osconfig-agent / google-cloud-ops-agent / open-vm-tools / pollinate / landscape-common; mask the serial/local getty; switch netplan to MAC-independent DHCP.
+
+### No self-updating, both variants (issue #71) — applied unconditionally, dev images too
+A measured image must only change when an operator changes it, so stage A always:
+- purges `unattended-upgrades` and **masks** `apt-daily{,-upgrade}.{timer,service}` (masking the timers matters on its own: they ship with `apt`, not with unattended-upgrades);
+- zeroes every `APT::Periodic::*` knob in `/etc/apt/apt.conf.d/20auto-upgrades`;
+- sets needrestart to **list-only** (`$nrconf{restart} = 'l'`), so even a manual `apt install` never restarts a service by itself.
+
+Why it is a build-time hard gate (`cvm/ci/check-no-auto-update.sh`, run on the final image in `build-cvm.yml`): an auto-upgrade restarts tapp-server → the in-memory app signer is re-derived → every on-chain node/service of every app on that node silently goes stale; and an auto kernel/initrd upgrade changes RTMR + `kernel_cmdline` → the image's whole reference-value set is invalidated. Both surface days later, far from the build. Package updates go through a rebuild (which regenerates reference values), never through the running node.
 
 ## Verification (passed)
 - Image static checks: all the above packages gone, getty masked, netplan = 01-dhcp, resolv.conf 3 lines, gcp initrd cryptpilot = 16.

--- a/cvm/build-tapp.sh
+++ b/cvm/build-tapp.sh
@@ -219,8 +219,10 @@ echo br_netfilter > /etc/modules-load.d/br_netfilter.conf
 #      library -- tapp-server included. tapp derives the app signer in memory, so a restart
 #      silently rotates it: on-chain nodes/services of every app on this node go stale with
 #      nobody having touched the machine (this is exactly what happened on wei-tapp 2026-07-28).
-#   2) an auto-upgraded kernel/initrd/grub changes RTMR + kernel_cmdline -> the whole image's
-#      attestation reference values are invalidated and every quote fails to verify.
+#   2) secondary (variant-dependent): where /boot or the ESP is writable at runtime, an
+#      auto-upgraded kernel/initrd/grub also changes RTMR + kernel_cmdline, invalidating the
+#      image's attestation reference values. With rw_overlay="ram" (config_dir/fde.toml) such
+#      writes evaporate on reboot -- (1) is the one that actually bites, and it bites at once.
 # Applied to BOTH variants, here rather than in the HARDEN=1 purge list: purging the package is
 # not enough on its own (the apt-daily* units ship with `apt` itself), and it was the dev
 # (HARDEN=0) image -- which purged nothing -- that actually bit us.
@@ -236,22 +238,34 @@ APT::Periodic::Unattended-Upgrade "0";
 APT::Periodic::AutocleanInterval "0";
 APTCONF
 # c) needrestart: list only, NEVER restart services on its own. This is the piece that restarted
-#    tapp-server; it applies to manual `apt install/upgrade` too, so an operator patching a
-#    library can no longer rotate the signer by accident -- they must restart deliberately.
+#    tapp-server (glibc upgrade -> `systemctl restart ... tapp-server.service containerd.service
+#    sysbox.service ...`); it applies to manual `apt install/upgrade` too, so an operator patching
+#    a library can no longer rotate the signer by accident -- they must restart deliberately.
+#    Filename MUST sort LAST: needrestart.conf ends with `foreach my $fn (sort <conf.d/*.conf>)`,
+#    so the last file read wins. A `00-` prefix would be silently overridden by any later drop-in.
 mkdir -p /etc/needrestart/conf.d
-cat > /etc/needrestart/conf.d/00-tapp-no-auto-restart.conf <<'NRCONF'
+cat > /etc/needrestart/conf.d/99-tapp-no-auto-restart.conf <<'NRCONF'
 # tapp: restart services only when an operator says so (issue #71).
 # 'l' = list outdated services, restart nothing. Do NOT set 'a' (automatic).
 $nrconf{restart} = 'l';
 $nrconf{kernelhints} = 0;
 NRCONF
-# d) fail the BUILD (not the fleet) if any of the above did not take effect
+# d) fail the BUILD (not the fleet) if any of the above did not take effect. Same four assertions
+#    as cvm/ci/check-no-auto-update.sh, but here the failure lands next to the command that caused
+#    it; the CI script re-checks them on the FINAL image (catches later apt runs pulling u-u back
+#    in as a Recommends, which this in-line check cannot see).
 for u in apt-daily.timer apt-daily-upgrade.timer apt-daily.service apt-daily-upgrade.service; do
   [ "$(readlink -f "/etc/systemd/system/$u" 2>/dev/null)" = /dev/null ] \
     || { echo "ERROR: $u is not masked -- auto-update would still run (issue #71)"; exit 1; }
 done
+dpkg -s unattended-upgrades >/dev/null 2>&1 \
+  && { echo "ERROR: unattended-upgrades still installed"; exit 1; } || true
 grep -q 'Unattended-Upgrade "0"' /etc/apt/apt.conf.d/20auto-upgrades \
   || { echo "ERROR: 20auto-upgrades not written"; exit 1; }
+# effective value = LAST assignment across needrestart.conf + conf.d (sorted); must be 'l'
+[ "$(cat /etc/needrestart/needrestart.conf /etc/needrestart/conf.d/*.conf 2>/dev/null \
+     | grep -oE "^\\\$nrconf\{restart\} *= *'.'" | tail -1)" = "\$nrconf{restart} = 'l'" ] \
+  || { echo "ERROR: effective needrestart restart mode is not 'l' -- services would auto-restart"; exit 1; }
 echo "auto-update: apt-daily* masked, unattended-upgrades purged, needrestart=list-only"
 
 # ---- pin container storage OFF the ephemeral RAM rootfs (rw_overlay="ram") -- UNCONDITIONAL ----

--- a/cvm/build-tapp.sh
+++ b/cvm/build-tapp.sh
@@ -212,6 +212,48 @@ systemctl enable docker tapp-server
 # crash the runner ("bridge-nf-call-iptables: no such file"). Persist it so every boot has it.
 echo br_netfilter > /etc/modules-load.d/br_netfilter.conf
 
+# ---- NO unattended package changes / service restarts (issue #71) -- UNCONDITIONAL ----
+# A measured image must only change when an operator changes it. Ubuntu's apt-daily-upgrade
+# (unattended-upgrades) breaks that twice over:
+#   1) needrestart, invoked after the upgrade, restarts every service linked against an updated
+#      library -- tapp-server included. tapp derives the app signer in memory, so a restart
+#      silently rotates it: on-chain nodes/services of every app on this node go stale with
+#      nobody having touched the machine (this is exactly what happened on wei-tapp 2026-07-28).
+#   2) an auto-upgraded kernel/initrd/grub changes RTMR + kernel_cmdline -> the whole image's
+#      attestation reference values are invalidated and every quote fails to verify.
+# Applied to BOTH variants, here rather than in the HARDEN=1 purge list: purging the package is
+# not enough on its own (the apt-daily* units ship with `apt` itself), and it was the dev
+# (HARDEN=0) image -- which purged nothing -- that actually bit us.
+dpkg -s unattended-upgrades >/dev/null 2>&1 && apt-get purge -y unattended-upgrades || true
+# a) kill the timers/services (mask, not disable: mask survives a package reinstall re-enabling them)
+systemctl mask apt-daily.timer apt-daily-upgrade.timer apt-daily.service apt-daily-upgrade.service
+# b) belt-and-braces for anything invoking apt.systemd.daily directly (the periodic knobs it reads)
+cat > /etc/apt/apt.conf.d/20auto-upgrades <<'APTCONF'
+// tapp: a measured image is never upgraded unattended (issue #71) -- see build-tapp.sh
+APT::Periodic::Update-Package-Lists "0";
+APT::Periodic::Download-Upgradeable-Packages "0";
+APT::Periodic::Unattended-Upgrade "0";
+APT::Periodic::AutocleanInterval "0";
+APTCONF
+# c) needrestart: list only, NEVER restart services on its own. This is the piece that restarted
+#    tapp-server; it applies to manual `apt install/upgrade` too, so an operator patching a
+#    library can no longer rotate the signer by accident -- they must restart deliberately.
+mkdir -p /etc/needrestart/conf.d
+cat > /etc/needrestart/conf.d/00-tapp-no-auto-restart.conf <<'NRCONF'
+# tapp: restart services only when an operator says so (issue #71).
+# 'l' = list outdated services, restart nothing. Do NOT set 'a' (automatic).
+$nrconf{restart} = 'l';
+$nrconf{kernelhints} = 0;
+NRCONF
+# d) fail the BUILD (not the fleet) if any of the above did not take effect
+for u in apt-daily.timer apt-daily-upgrade.timer apt-daily.service apt-daily-upgrade.service; do
+  [ "$(readlink -f "/etc/systemd/system/$u" 2>/dev/null)" = /dev/null ] \
+    || { echo "ERROR: $u is not masked -- auto-update would still run (issue #71)"; exit 1; }
+done
+grep -q 'Unattended-Upgrade "0"' /etc/apt/apt.conf.d/20auto-upgrades \
+  || { echo "ERROR: 20auto-upgrades not written"; exit 1; }
+echo "auto-update: apt-daily* masked, unattended-upgrades purged, needrestart=list-only"
+
 # ---- pin container storage OFF the ephemeral RAM rootfs (rw_overlay="ram") -- UNCONDITIONAL ----
 # The cryptpilot writable rootfs overlay is RAM-backed and RAM-capped, so container state MUST NOT
 # accumulate on "/". Independent of Sysbox. Two distinct stores must both move to the /data disk:
@@ -340,11 +382,13 @@ EOF
 # ===== Hardening (appended when HARDEN=1): remove software that can bypass tapp and mutate the environment (Tier1+Tier2, audit in doc §11) =====
 if [ "${HARDEN:-1}" = 1 ]; then
   echo "==> [harden] HARDEN=1: purge Tier1/2 + mask console getty + replace netplan with a MAC-agnostic one"
+  # NOTE: unattended-upgrades is purged UNCONDITIONALLY in the block above (issue #71) --
+  # it is deliberately no longer listed here, dev images must not keep auto-upgrades either.
   cat >> "$TMPD/provision-base.sh" <<'EOF'
 PURGE_PKGS="openssh-server \
   google-guest-agent google-compute-engine google-compute-engine-oslogin google-osconfig-agent \
   cloud-init cloud-initramfs-copymods cloud-initramfs-dyn-netconf \
-  snapd unattended-upgrades open-vm-tools google-cloud-ops-agent pollinate \
+  snapd open-vm-tools google-cloud-ops-agent pollinate \
   landscape-common ubuntu-pro-client ubuntu-advantage-tools"
 to_purge=""
 for p in $PURGE_PKGS; do dpkg -s "$p" >/dev/null 2>&1 && to_purge="$to_purge $p" || true; done

--- a/cvm/ci/check-no-auto-update.sh
+++ b/cvm/ci/check-no-auto-update.sh
@@ -4,17 +4,21 @@
 # Offline (no boot) assertion that a built image cannot change itself: no unattended apt
 # upgrade, and no automatic service restart after a manual one (issue #71).
 #
-# Why this is a CI gate and not just a build step: an auto-upgrade on a measured node
-# restarts tapp-server -> the in-memory app signer rotates -> every on-chain node/service
-# of every app on that node goes stale, with no operator action; and an auto kernel/initrd
-# upgrade changes RTMR + kernel_cmdline, invalidating the image's attestation reference
-# values. Both failures surface days later, far from the build that caused them.
+# Why this is a CI gate and not just a build-time check: an auto-upgrade on a measured node
+# restarts tapp-server (observed: a glibc upgrade restarting tapp-server + containerd +
+# sysbox) -> the in-memory app signer rotates -> every on-chain node/service of every app on
+# that node goes stale, with no operator action. The failure surfaces days later, far from
+# the build. Running on the FINAL converted image also catches what an in-line build check
+# cannot: a later apt step pulling unattended-upgrades back in as a Recommends.
 #
-# Checks (on the final, converted image — so it also catches a convert-time regression):
+# Checks:
 #   1. apt-daily{,-upgrade}.{timer,service} masked (-> /dev/null)
 #   2. unattended-upgrades purged (no /usr/bin/unattended-upgrade)
 #   3. /etc/apt/apt.conf.d/20auto-upgrades sets every periodic knob to "0"
-#   4. needrestart drop-in present and set to list-only ($nrconf{restart} = 'l')
+#   4. the EFFECTIVE needrestart mode is 'l' (list-only) — i.e. the last assignment across
+#      needrestart.conf + conf.d/*.conf in read order, not merely "our drop-in says 'l'":
+#      needrestart.conf ends with `foreach my $fn (sort <conf.d/*.conf>)`, so a later-sorting
+#      drop-in silently wins.
 #
 # Usage: cvm/ci/check-no-auto-update.sh out-dev.qcow2
 # Exit:  0 = all checks pass, 1 = a check failed, 2 = setup/mount error.
@@ -26,8 +30,8 @@ IMG="${1:?usage: $0 <image.qcow2>}"
 [ -f "$IMG" ] || { echo "image not found: $IMG" >&2; exit 2; }
 command -v guestfish >/dev/null || { echo "guestfish is required" >&2; exit 2; }
 
-# Converted images keep the rootfs on the cryptpilot LVM; a pre-convert (stage A) image is
-# a plain partition. Try the converted layout first, fall back to the plain one.
+# Converted images keep the rootfs on the cryptpilot LVM; a pre-convert (stage A) image is a
+# plain partition. Try the converted layout first, fall back to the plain one.
 MOUNT_CONVERTED='run
 vgscan
 vg-activate-all true
@@ -35,59 +39,64 @@ mount-ro /dev/cryptpilot/rootfs /'
 MOUNT_PLAIN='run
 mount-ro /dev/sda1 /'
 
-gf() { # gf <mount-preamble> <commands...>  -> stdout+stderr of the guestfish run
-  printf '%s\n%s\n' "$1" "$2" | guestfish --ro -a "$IMG" 2>&1
-}
-
-MOUNT="$MOUNT_CONVERTED"
-if ! gf "$MOUNT" 'is-dir /etc' | grep -qx true; then
-  MOUNT="$MOUNT_PLAIN"
-  gf "$MOUNT" 'is-dir /etc' | grep -qx true || { echo "cannot mount a rootfs in $IMG" >&2; exit 2; }
-  echo "==> $IMG: plain (pre-convert) layout"
-else
-  echo "==> $IMG: converted (cryptpilot) layout"
-fi
-
-# One pass for everything: `ll` shows symlink targets (tolerant of missing entries, unlike
-# readlink which aborts the guestfish script), is-file prints true/false, cat prints content.
-OUT="$(gf "$MOUNT" 'll /etc/systemd/system/
+# ONE guestfish run for everything: on the CI builder there is no /dev/kvm, so each libguestfs
+# appliance boot costs minutes under TCG. `ll` prints symlink targets and `is-file` prints
+# true/false without aborting on missing paths, so all the tolerant commands run first; the
+# `cat`s go last, where an abort (missing file) costs nothing — the checks below then fail on
+# the absent content, and the is-file flags say which file was missing.
+CMDS='ll /etc/systemd/system/
 is-file /usr/bin/unattended-upgrade
 is-file /etc/apt/apt.conf.d/20auto-upgrades
-is-file /etc/needrestart/conf.d/00-tapp-no-auto-restart.conf')"
+is-file /etc/needrestart/conf.d/99-tapp-no-auto-restart.conf
+cat /etc/apt/apt.conf.d/20auto-upgrades
+cat /etc/needrestart/needrestart.conf
+glob cat /etc/needrestart/conf.d/*.conf'
+
+run() { printf '%s\n%s\n' "$1" "$CMDS" | guestfish --ro -a "$IMG" 2>&1; }
+
+# The mount is probed by the same run: is-file only prints true/false once a rootfs is mounted.
+LAYOUT=converted
+OUT="$(run "$MOUNT_CONVERTED")"
+if ! grep -qx 'true\|false' <<<"$OUT"; then
+  LAYOUT=plain
+  OUT="$(run "$MOUNT_PLAIN")"
+  grep -qx 'true\|false' <<<"$OUT" || { echo "cannot mount a rootfs in $IMG" >&2; echo "$OUT" >&2; exit 2; }
+fi
+echo "==> $IMG: $LAYOUT layout"
 
 fail=0
 say_fail() { echo "  FAIL: $1"; fail=1; }
 
-# 1. apt-daily* masked
+# 1. apt-daily* masked (-qF: unit names contain dots, which are ERE wildcards)
 for u in apt-daily.timer apt-daily-upgrade.timer apt-daily.service apt-daily-upgrade.service; do
-  grep -qE "$u -> /dev/null" <<<"$OUT" \
+  grep -qF "$u -> /dev/null" <<<"$OUT" \
     && echo "  ok: $u masked" \
     || say_fail "$u is NOT masked in /etc/systemd/system (auto-upgrade can still fire)"
 done
 
-# 2. unattended-upgrades gone. The three is-file results are the only bare true/false lines
+# 2/3/4a. the three is-file results are the only bare true/false lines, in command order
 readarray -t FLAGS < <(grep -x 'true\|false' <<<"$OUT")
-# FLAGS = (unattended-upgrade, 20auto-upgrades, needrestart drop-in) in command order
 [ "${FLAGS[0]:-}" = false ] \
   && echo "  ok: unattended-upgrades purged" \
   || say_fail "/usr/bin/unattended-upgrade still present (unattended-upgrades not purged)"
+[ "${FLAGS[1]:-}" = true ] || say_fail "/etc/apt/apt.conf.d/20auto-upgrades missing"
+[ "${FLAGS[2]:-}" = true ] || say_fail "/etc/needrestart/conf.d/99-tapp-no-auto-restart.conf missing"
 
-# 3 + 4. config files present, then their content
-if [ "${FLAGS[1]:-}" = true ] && [ "${FLAGS[2]:-}" = true ]; then
-  CONF="$(gf "$MOUNT" 'cat /etc/apt/apt.conf.d/20auto-upgrades
-cat /etc/needrestart/conf.d/00-tapp-no-auto-restart.conf')"
-  for knob in Update-Package-Lists Download-Upgradeable-Packages Unattended-Upgrade; do
-    grep -qE "APT::Periodic::$knob \"0\";" <<<"$CONF" \
-      && echo "  ok: APT::Periodic::$knob = 0" \
-      || say_fail "APT::Periodic::$knob is not \"0\" in 20auto-upgrades"
-  done
-  grep -qE "^\\\$nrconf\{restart\} *= *'l';" <<<"$CONF" \
-    && echo "  ok: needrestart = list-only" \
-    || say_fail "needrestart drop-in does not set \$nrconf{restart} = 'l' (services would auto-restart)"
-else
-  [ "${FLAGS[1]:-}" = true ] || say_fail "/etc/apt/apt.conf.d/20auto-upgrades missing"
-  [ "${FLAGS[2]:-}" = true ] || say_fail "/etc/needrestart/conf.d/00-tapp-no-auto-restart.conf missing"
-fi
+# 3. every periodic knob off
+for knob in Update-Package-Lists Download-Upgradeable-Packages Unattended-Upgrade AutocleanInterval; do
+  grep -qE "APT::Periodic::$knob \"0\";" <<<"$OUT" \
+    && echo "  ok: APT::Periodic::$knob = 0" \
+    || say_fail "APT::Periodic::$knob is not \"0\" in 20auto-upgrades"
+done
+
+# 4. EFFECTIVE needrestart mode: last uncommented assignment wins (main conf, then sorted conf.d).
+#    Checking our drop-in's content alone would pass even when a later-sorting drop-in overrides it.
+EFFECTIVE="$(grep -oE "^\\\$nrconf\{restart\} *= *'.'" <<<"$OUT" | tail -1 | grep -oE "'.'")"
+case "${EFFECTIVE:-none}" in
+  "'l'") echo "  ok: effective needrestart mode = 'l' (list-only)" ;;
+  none)  say_fail "no \$nrconf{restart} assignment in /etc/needrestart (needrestart would use its own default)" ;;
+  *)     say_fail "effective needrestart mode is ${EFFECTIVE} — a later drop-in overrides list-only; services would auto-restart" ;;
+esac
 
 if [ "$fail" -ne 0 ]; then
   echo "==== raw guestfish output ===="

--- a/cvm/ci/check-no-auto-update.sh
+++ b/cvm/ci/check-no-auto-update.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# check-no-auto-update.sh <image.qcow2>
+#
+# Offline (no boot) assertion that a built image cannot change itself: no unattended apt
+# upgrade, and no automatic service restart after a manual one (issue #71).
+#
+# Why this is a CI gate and not just a build step: an auto-upgrade on a measured node
+# restarts tapp-server -> the in-memory app signer rotates -> every on-chain node/service
+# of every app on that node goes stale, with no operator action; and an auto kernel/initrd
+# upgrade changes RTMR + kernel_cmdline, invalidating the image's attestation reference
+# values. Both failures surface days later, far from the build that caused them.
+#
+# Checks (on the final, converted image — so it also catches a convert-time regression):
+#   1. apt-daily{,-upgrade}.{timer,service} masked (-> /dev/null)
+#   2. unattended-upgrades purged (no /usr/bin/unattended-upgrade)
+#   3. /etc/apt/apt.conf.d/20auto-upgrades sets every periodic knob to "0"
+#   4. needrestart drop-in present and set to list-only ($nrconf{restart} = 'l')
+#
+# Usage: cvm/ci/check-no-auto-update.sh out-dev.qcow2
+# Exit:  0 = all checks pass, 1 = a check failed, 2 = setup/mount error.
+
+set -uo pipefail
+export LIBGUESTFS_BACKEND=direct
+
+IMG="${1:?usage: $0 <image.qcow2>}"
+[ -f "$IMG" ] || { echo "image not found: $IMG" >&2; exit 2; }
+command -v guestfish >/dev/null || { echo "guestfish is required" >&2; exit 2; }
+
+# Converted images keep the rootfs on the cryptpilot LVM; a pre-convert (stage A) image is
+# a plain partition. Try the converted layout first, fall back to the plain one.
+MOUNT_CONVERTED='run
+vgscan
+vg-activate-all true
+mount-ro /dev/cryptpilot/rootfs /'
+MOUNT_PLAIN='run
+mount-ro /dev/sda1 /'
+
+gf() { # gf <mount-preamble> <commands...>  -> stdout+stderr of the guestfish run
+  printf '%s\n%s\n' "$1" "$2" | guestfish --ro -a "$IMG" 2>&1
+}
+
+MOUNT="$MOUNT_CONVERTED"
+if ! gf "$MOUNT" 'is-dir /etc' | grep -qx true; then
+  MOUNT="$MOUNT_PLAIN"
+  gf "$MOUNT" 'is-dir /etc' | grep -qx true || { echo "cannot mount a rootfs in $IMG" >&2; exit 2; }
+  echo "==> $IMG: plain (pre-convert) layout"
+else
+  echo "==> $IMG: converted (cryptpilot) layout"
+fi
+
+# One pass for everything: `ll` shows symlink targets (tolerant of missing entries, unlike
+# readlink which aborts the guestfish script), is-file prints true/false, cat prints content.
+OUT="$(gf "$MOUNT" 'll /etc/systemd/system/
+is-file /usr/bin/unattended-upgrade
+is-file /etc/apt/apt.conf.d/20auto-upgrades
+is-file /etc/needrestart/conf.d/00-tapp-no-auto-restart.conf')"
+
+fail=0
+say_fail() { echo "  FAIL: $1"; fail=1; }
+
+# 1. apt-daily* masked
+for u in apt-daily.timer apt-daily-upgrade.timer apt-daily.service apt-daily-upgrade.service; do
+  grep -qE "$u -> /dev/null" <<<"$OUT" \
+    && echo "  ok: $u masked" \
+    || say_fail "$u is NOT masked in /etc/systemd/system (auto-upgrade can still fire)"
+done
+
+# 2. unattended-upgrades gone. The three is-file results are the only bare true/false lines
+readarray -t FLAGS < <(grep -x 'true\|false' <<<"$OUT")
+# FLAGS = (unattended-upgrade, 20auto-upgrades, needrestart drop-in) in command order
+[ "${FLAGS[0]:-}" = false ] \
+  && echo "  ok: unattended-upgrades purged" \
+  || say_fail "/usr/bin/unattended-upgrade still present (unattended-upgrades not purged)"
+
+# 3 + 4. config files present, then their content
+if [ "${FLAGS[1]:-}" = true ] && [ "${FLAGS[2]:-}" = true ]; then
+  CONF="$(gf "$MOUNT" 'cat /etc/apt/apt.conf.d/20auto-upgrades
+cat /etc/needrestart/conf.d/00-tapp-no-auto-restart.conf')"
+  for knob in Update-Package-Lists Download-Upgradeable-Packages Unattended-Upgrade; do
+    grep -qE "APT::Periodic::$knob \"0\";" <<<"$CONF" \
+      && echo "  ok: APT::Periodic::$knob = 0" \
+      || say_fail "APT::Periodic::$knob is not \"0\" in 20auto-upgrades"
+  done
+  grep -qE "^\\\$nrconf\{restart\} *= *'l';" <<<"$CONF" \
+    && echo "  ok: needrestart = list-only" \
+    || say_fail "needrestart drop-in does not set \$nrconf{restart} = 'l' (services would auto-restart)"
+else
+  [ "${FLAGS[1]:-}" = true ] || say_fail "/etc/apt/apt.conf.d/20auto-upgrades missing"
+  [ "${FLAGS[2]:-}" = true ] || say_fail "/etc/needrestart/conf.d/00-tapp-no-auto-restart.conf missing"
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "==== raw guestfish output ===="
+  echo "$OUT"
+  echo "AUTO-UPDATE CHECK FAILED for $IMG (issue #71)" >&2
+  exit 1
+fi
+echo "AUTO-UPDATE CHECK PASS: $IMG cannot upgrade or restart itself"

--- a/cvm/cryptpilot-gcp-boot-fix.md
+++ b/cvm/cryptpilot-gcp-boot-fix.md
@@ -386,7 +386,7 @@ The goal of a confidential appliance is that "the instance's internal environmen
 | 🔴 T1 | `cloud-init` | create users, write files, run commands from metadata/user-data | purge |
 | 🔴 T1 | `serial-getty@ttyS0` | GCP serial console login | mask |
 | 🟠 T2 | `snapd` | remotely install/refresh snaps | purge + clean /snap |
-| 🟠 T2 | `unattended-upgrades` | automatically change packages | purge |
+| 🔴 T1 | `unattended-upgrades` + `apt-daily{,-upgrade}.{timer,service}` + `needrestart` | automatically change packages **and restart tapp-server** → signer rotates + RTMR/cmdline reference values die (issue #71) | purge + mask timers + needrestart list-only — **unconditional, dev images too** |
 | 🟠 T2 | `open-vm-tools` | hypervisor → guest operations | purge |
 | 🟠 T2 | `google-cloud-ops-agent` | exfiltrate monitoring/logs | purge |
 | 🟠 T2 | `pollinate` | contact an external server at boot | purge |


### PR DESCRIPTION
Closes #71 (image-baseline part).

## 问题

2026-07-28，`wei-tapp` 的 apt 自动更新装完包后由 needrestart 顺手重启了一批服务，**tapp-server 也在里面**。tapp 的 app signer 是内存里派生的，一重启就换地址 → `0g-sandbox-provider-dev` 链上在册的 node / service 全部失效。没人碰机器，也没 reboot。

更狠的是同一条路径能自动升内核/initrd —— 那会改 RTMR + `kernel_cmdline`，整个镜像的参考值集体作废，所有 quote 验不过。

之前 `HARDEN=1`（prod）会 purge `unattended-upgrades`，但：
- 出事的是 **dev 镜像（`HARDEN=0`）**，那条分支根本不走；
- 就算走了也不够——`apt-daily{,-upgrade}.timer` 是 `apt` 自带的，跟 unattended-upgrades 不是一个包；
- **`needrestart` 两个变体都没管**，而它才是真正把 tapp-server 重启掉的那一环。

## 改动

**`cvm/build-tapp.sh`** — stage A 加一段**无条件**（dev/prod 都走）的块：

- purge `unattended-upgrades`
- **mask** `apt-daily{,-upgrade}.{timer,service}`（mask 而非 disable：重装包不会把它重新 enable 回来）
- `/etc/apt/apt.conf.d/20auto-upgrades` 所有 `APT::Periodic::*` 置 `"0"`
- needrestart drop-in 设成只列不重启（`$nrconf{restart} = 'l'`）—— 顺带覆盖手工 `apt install`，运维打补丁不会再顺手转掉 signer，必须显式重启
- 任何一项没生效就 **让构建失败**

`unattended-upgrades` 从 `HARDEN=1` 的 purge 列表移除（已由上面无条件处理）。

**`cvm/ci/check-no-auto-update.sh`**（新）— 用 guestfish 离线检查**转换后的最终镜像**：mask 是否生效、包是否还在、两个配置文件内容是否正确。不用开机，也能抓到 convert 阶段引入的回归。

**`.github/workflows/build-cvm.yml`** — build 之后、publish 之前加一步**硬性 gate**。跟下面那个 boot smoke test 不同，那个是 advisory，这个不过就不发布。

**文档** — `cvm/README.md` 新增一节；`cryptpilot-gcp-boot-fix.md` §11 把 unattended-upgrades 从 T2 提到 T1 并写明原因。

## 验证

- 两个脚本 `bash -n`；从 `build-tapp.sh` 抽出生成的 guest 脚本单独 parse，均通过
- 新加的块在 `ubuntu:24.04` 容器里实跑（`systemctl` 用 stub 顶替，容器无 systemd）：4 个 mask 符号链接 + 两个配置文件内容均符合预期
- 检查脚本用模拟 guestfish 输出跑正反两遍：正常放行；把一个 timer 改成未 mask 后正确报错退 1
- **真实镜像上未跑过** —— 需要在 CI 的 al8 runner 上完整 build 一次验证

## 不在本 PR 范围

- **锁内核版本（`apt-mark hold`）**：得插在 stage B 装完内核、convert 之前，而且 hold 会连带挡住 `prepare-tapp.sh` 里对 6.8 内核的 purge，有搞挂构建的风险。定时器 masked 之后自动升级已经没了，这个只是手工场景的额外保险，建议单独一次改动单独验。
- **存量节点**：本改动只影响新出的镜像，已部署的机器需要重新出镜像重部署。手工顶包办法 （`systemctl mask apt-daily.timer apt-daily-upgrade.timer` + `99-no-autorestart.conf`）**一重启就失效** —— rootfs 是 `rw_overlay = "ram"`（`cvm/config_dir/fde.toml`），写进 /etc 的东西 reboot 即蒸发，所以每次 boot 都得重做，真正的解只有换新镜像。
- **signer 持久化**（#71 建议 4）和 #72 的内建对账 + `/metrics` —— 另开。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

