### PR TITLE
feat(cvm): version the CVM image separately from the binary it ships (image_rev)

### DIFF
--- a/.github/workflows/build-cvm.yml
+++ b/.github/workflows/build-cvm.yml
@@ -13,8 +13,16 @@
 #                        Per-owner image + per-owner reference set (legacy mode).
 #                        Identifiers: image og-tdx-dev-grub-<ver>-<owner>, refval .../<owner>.json
 #
-# Dimensions: cloud × boot_format × env × version (× owner only in custom mode).
+# Dimensions: cloud × boot_format × env × image version (× owner only in custom mode).
 # KBS/KMS is fixed (vars.TAPP_KBS_URLS), not per-build.
+#
+# TWO versions, do not conflate them (docs/VERSIONING.md → CVM image):
+#   version    tapp-server release tag. Used ONLY to fetch the binary.
+#   image_rev  revision of the IMAGE at that binary version. <ver> below means <version>[-r<rev>]
+#              (rev 1 = no suffix) and keys the image name, reference-value path and AS policy id.
+#              Bump it whenever the image changes but the binary does not — otherwise the rebuilt
+#              image re-registers its measurements under the old policy id and every node still
+#              running the previous image silently stops verifying.
 
 name: build-cvm
 
@@ -39,6 +47,10 @@ on:
       version:
         description: "tapp-server release tag (e.g. v0.1.0)"
         required: true
+      image_rev:
+        description: "image revision for THIS tapp-server version. Bump when the image changes but the binary does not (kernel, docker, CVM config, hardening). 1 = no suffix (as before); 2+ appends -r<N> to the image name, reference-value path and AS policy id, so the previous image's values stay registered and its nodes keep verifying."
+        required: false
+        default: "1"
       env:
         description: "image variant"
         type: choice
@@ -64,7 +76,7 @@ on:
         default: false
 
 concurrency:
-  group: build-cvm-${{ inputs.cloud || 'gcp' }}-${{ inputs.boot_format }}-${{ inputs.build_mode || 'canonical' }}-${{ inputs.version }}-${{ inputs.owner }}
+  group: build-cvm-${{ inputs.cloud || 'gcp' }}-${{ inputs.boot_format }}-${{ inputs.build_mode || 'canonical' }}-${{ inputs.version }}-r${{ inputs.image_rev || '1' }}-${{ inputs.owner }}
   cancel-in-progress: false
 
 # The reference-values step pushes a refvalues/* branch and opens a PR into dev with GITHUB_TOKEN;
@@ -84,7 +96,8 @@ jobs:
     env:
       # All fixed config lives in repo/org Actions Variables (Settings → Secrets and variables →
       # Actions → Variables), editable without touching this file; the `|| 'default'` is a fallback.
-      VERSION: ${{ inputs.version }}
+      VERSION: ${{ inputs.version }}          # tapp-server release tag — ONLY for fetching the binary
+      IMAGE_REV: ${{ inputs.image_rev || '1' }}
       PUBLISH: ${{ inputs.publish }}
       BUILD_MODE: ${{ inputs.build_mode || 'canonical' }}
       # OWNER is only meaningful in custom mode; empty otherwise so no step can
@@ -130,6 +143,12 @@ jobs:
               FAIL=1
             fi
           fi
+          # image_rev keys the image identity (name / refval path / policy id) — a non-numeric or
+          # zero value would silently produce a bogus identity, so reject it before building.
+          if ! printf '%s' "$IMAGE_REV" | grep -qE '^[1-9][0-9]*$'; then
+            echo "error: image_rev must be a positive integer; got '${IMAGE_REV:-<empty>}'." >&2
+            FAIL=1
+          fi
           # env=both runs two matrix jobs; a fixed image_name would make them clobber each other.
           if [ -n "${{ inputs.image_name }}" ] && [ "${{ inputs.env }}" = "both" ]; then
             echo "error: image_name requires a single env (dev or prod), not both." >&2
@@ -143,7 +162,7 @@ jobs:
           fi
           exit $FAIL
 
-      - name: Resolve variant (env → HARDEN + image base)
+      - name: Resolve variant (env → HARDEN + image base) and image version
         id: v
         run: |
           if [ "${{ matrix.env }}" = prod ]; then
@@ -153,6 +172,16 @@ jobs:
             echo "harden=0"           >> "$GITHUB_OUTPUT"
             echo "imgbase=og-tdx-dev" >> "$GITHUB_OUTPUT"
           fi
+          # IMAGE VERSION vs BINARY VERSION. $VERSION identifies the tapp-server binary and is used
+          # for exactly one thing: downloading it. Everything that identifies the IMAGE — published
+          # name, reference-value path, AS policy id — uses $IMGVER, because the image can change
+          # while the binary does not (kernel, docker pin, CVM config, hardening). Reusing $VERSION
+          # for a changed image would overwrite the reference values already registered for the old
+          # one under the same policy id, and every node still running it would stop verifying.
+          # rev 1 == no suffix, so identifiers built before image_rev existed keep working.
+          if [ "$IMAGE_REV" = 1 ]; then IMGVER="$VERSION"; else IMGVER="${VERSION}-r${IMAGE_REV}"; fi
+          echo "imgver=$IMGVER" >> "$GITHUB_OUTPUT"
+          echo "image version: $IMGVER (tapp-server binary: $VERSION)"
 
       - name: Fetch build inputs (base image + 0.8.0 guest deb)
         run: cvm/ci/fetch-inputs.sh "$VERSION"   # → cvm/base-noble.qcow2 + cryptpilot-fde-guest_0.8.0_amd64.deb
@@ -225,7 +254,8 @@ jobs:
         run: |
           cd cvm
           IMG="${{ inputs.image_name }}"
-          [ -n "$IMG" ] || IMG="${{ steps.v.outputs.imgbase }}-${BOOT_FORMAT}-${VERSION//./-}${{ steps.names.outputs.img_suffix }}"
+          IMGVER="${{ steps.v.outputs.imgver }}"
+          [ -n "$IMG" ] || IMG="${{ steps.v.outputs.imgbase }}-${BOOT_FORMAT}-${IMGVER//./-}${{ steps.names.outputs.img_suffix }}"
           IMAGE_FAMILY="${{ steps.v.outputs.imgbase }}-${BOOT_FORMAT}${{ steps.names.outputs.family_suffix }}" \
           OVERWRITE=${{ inputs.overwrite && '1' || '0' }} \
             ./publish-gcp-image.sh "out-${{ matrix.env }}.qcow2" "$IMG"
@@ -235,7 +265,8 @@ jobs:
         run: |
           cd cvm
           IMG="${{ inputs.image_name }}"
-          [ -n "$IMG" ] || IMG="${{ steps.v.outputs.imgbase }}-${BOOT_FORMAT}-${VERSION//./-}${{ steps.names.outputs.img_suffix }}"
+          IMGVER="${{ steps.v.outputs.imgver }}"
+          [ -n "$IMG" ] || IMG="${{ steps.v.outputs.imgbase }}-${BOOT_FORMAT}-${IMGVER//./-}${{ steps.names.outputs.img_suffix }}"
           ALIYUN_REGION="$ALIYUN_REGION" OSS_BUCKET="$OSS_BUCKET" \
           OVERWRITE=${{ inputs.overwrite && '1' || '0' }} \
             ./publish-ali-image.sh "out-${{ matrix.env }}.qcow2" "$IMG"
@@ -247,13 +278,14 @@ jobs:
           # see no owner arg and use the <env>.json path / no-owner policy id.
           # custom: $OWNER is the full 0x address (scripts strip/lowercase themselves).
           cd cvm
-          ci/gen-reference-values.sh "out-${{ matrix.env }}.qcow2" "$CLOUD" "$BOOT_FORMAT" "$VERSION" "${{ matrix.env }}" $OWNER
+          IMGVER="${{ steps.v.outputs.imgver }}"
+          ci/gen-reference-values.sh "out-${{ matrix.env }}.qcow2" "$CLOUD" "$BOOT_FORMAT" "$IMGVER" "${{ matrix.env }}" $OWNER
           cd ..
-          verifier/register-shared-as.sh "$CLOUD" "$BOOT_FORMAT" "$VERSION" "${{ matrix.env }}" $OWNER "$AS_ENDPOINT"
+          verifier/register-shared-as.sh "$CLOUD" "$BOOT_FORMAT" "$IMGVER" "${{ matrix.env }}" $OWNER "$AS_ENDPOINT"
 
       - name: Open PR with the new reference values → dev
         if: ${{ env.PUBLISH == 'true' }}
-        run: cvm/ci/open-refvalues-pr.sh "$CLOUD" "$BOOT_FORMAT" "$VERSION" "${{ matrix.env }}" $OWNER
+        run: cvm/ci/open-refvalues-pr.sh "$CLOUD" "$BOOT_FORMAT" "${{ steps.v.outputs.imgver }}" "${{ matrix.env }}" $OWNER
         env:
           # PAT so `gh pr create` works even if the org disables "Actions create/approve PRs".
           # git push still uses GITHUB_TOKEN via the permissions block above. Falls back if unset.

--- a/cvm/README.md
+++ b/cvm/README.md
@@ -28,6 +28,8 @@ Because they yield different images/measurements, **`boot_format` (like `cloud`,
 - reference value: canonical `…/<version>/<env>.json`; custom `…/<version>/<env>/<owner>.json`
 - AS policy id: canonical `0g-tapp-<cloud>-<boot_format>-<version>-<env>`; custom appends `-<owner>`
 
+Here `<version>` is the **image** version `<tapp-server tag>[-r<image_rev>]` (`build-cvm` inputs `version` + `image_rev`; rev 1 = no suffix), **not** the binary version — the two diverge whenever the image changes and the binary does not, which is most `cvm/` changes. Rebuilding a changed image under an already-published identity re-registers new measurements behind the **same AS policy id**, and every node still running the old image stops verifying on the spot. See [docs/VERSIONING.md → CVM image](../docs/VERSIONING.md#cvm-image).
+
 ### Platform differences (everything else is shared)
 | | GCP (`gcp`) | Alibaba Cloud (`ali`) |
 |---|---|---|

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This workspace produces two binaries — **tapp-server** and **tapp-cli** — plus an internal library **tapp-common**. Alongside them lives the on-chain **TappRegistry** contract, which is also versioned. **Compatibility between artifacts is resolved at runtime rather than by matching version numbers** — see [Compatibility](#compatibility) below.
+This workspace produces two binaries — **tapp-server** and **tapp-cli** — plus an internal library **tapp-common**. Alongside them live the on-chain **TappRegistry** contract and the **CVM image** (the confidential VM the server runs inside), both also versioned. **Compatibility between artifacts is resolved at runtime rather than by matching version numbers** — see [Compatibility](#compatibility) below.
 
 ## Version Sources
 
@@ -12,6 +12,7 @@ This workspace produces two binaries — **tapp-server** and **tapp-cli** — pl
 | tapp-cli | `tapp-cli/Cargo.toml` → `[package] version` | `tapp-cli --version` |
 | tapp-common | `tapp-common/Cargo.toml` → `[package] version` | (internal, no standalone release) |
 | TappRegistry (contract) | Implementation version (on-chain `version()` view — see [Contract](#contract-tappregistry)) | `version()` call against the proxy |
+| CVM image | `build-cvm` workflow inputs `version` + `image_rev` — see [CVM image](#cvm-image) | published image name, e.g. `og-tdx-dev-grub-v0-3-0-r2` |
 
 ## How to Build
 
@@ -71,12 +72,23 @@ Version is injected at compile time via `env!("CARGO_PKG_VERSION")` — no hardc
 
 tapp-common is an internal dependency, not a standalone release artifact. Bump its version only on breaking API changes that affect downstream crates. Both tapp-cli and tapp-server pin it via path dependency, so a tapp-common bump requires rebuilding dependents.
 
+### CVM image release
+
+The image is **not** built from a git tag — it is built by dispatching the `build-cvm` workflow. Its version is `<tapp-server version>[-r<image_rev>]`:
+
+1. Dispatch `build-cvm` with `version` = the tapp-server release tag and `image_rev` = the image revision (see [CVM image](#cvm-image) for when to bump it).
+2. The workflow publishes the image, writes the reference values and registers the AS policy — all three keyed on the image version, not the binary version.
+3. Tag the commit the image was built from, for traceability: `git tag cvm-image-v0.3.0-r2 && git push origin cvm-image-v0.3.0-r2`.
+
+The `cvm-image-*` tag does **not** trigger a binary release — `build.yml` fires on `v*` only. It records *which source produced this image*; nothing consumes it.
+
 ## Tag Naming Convention
 
 ```
 tapp-server-v<version>    # e.g. tapp-server-v0.1.0
 tapp-cli-v<version>       # e.g. tapp-cli-v0.1.0
 contract-v<version>       # e.g. contract-v0.1.0  (TappRegistry implementation)
+cvm-image-v<version>      # e.g. cvm-image-v0.3.0-r2  (traceability only, builds no binary)
 ```
 
 Using the `v` prefix with crate name avoids ambiguity and sorts correctly in `git tag -l`.
@@ -115,7 +127,34 @@ The contract's "interface" is its **ABI**:
 | **Y** — MINOR | The **ABI changed** — external/public function or event added, removed, or changed. |
 | **Z** — PATCH | Logic-only change with an **unchanged ABI** — and it **must preserve storage layout** (beacon-upgrade safety, see below). |
 
-Rules that apply to all three:
+### CVM image
+
+The image is a **separate artifact from the binary it carries**, and it is measured: its identity is what remote attestation verifies against. It has no version number of its own — it is identified by the tapp-server version it ships plus a **revision**:
+
+```
+<tapp-server version>[-r<image_rev>]      # rev 1 = no suffix: v0.3.0, v0.3.0-r2, v0.3.0-r3 …
+```
+
+| Digit | Bump when |
+|---|---|
+| `<tapp-server version>` | A new tapp-server release goes into the image. Revision restarts at 1. |
+| **`-r<N>`** — REVISION | The **image content changed while the binary did not**: kernel, docker/containerd pin, CVM/cryptpilot config, hardening, anything in `cvm/`. |
+
+**Never rebuild a changed image under an identity that is already published.** The image version keys three things at once:
+
+| | example |
+|---|---|
+| published image name | `og-tdx-dev-grub-v0-3-0-r2` |
+| reference values | `verifier/reference-values/gcp/grub/v0.3.0-r2/dev.json` |
+| AS policy id | `0g-tapp-gcp-grub-v0.3.0-r2-dev` |
+
+Any change to the image changes its measurements. Reusing the identity makes `register-shared-as.sh` overwrite the reference values behind the **same policy id**, so every node still running the previous image fails verification from that moment on — no deploy, no warning. Bumping the revision leaves the old values registered and gives the new image its own policy.
+
+Consequence to plan for: **verifiers must be told the new policy id** (`verify-app --policy-ids`, plus anywhere ops has one written down). That is the cost of separate identities, and it is much cheaper than a silent fleet-wide verification failure.
+
+Do **not** bump tapp-server just to give a changed image a new number — the binary did not change, and a release whose artifact is byte-identical to the previous one is a lie to everyone reading the version.
+
+Rules that apply to all three binaries/contract:
 
 - `X` is reserved for product milestones; code changes never bump it on their own.
 - Bump the relevant artifact's version in the **same PR** that makes the change.
@@ -132,6 +171,10 @@ Rules that apply to all three:
 - **Add a `--json` output flag to an existing CLI command** (no RPC touched) →
   **`tapp-cli` MINOR bump**, everything else unchanged. The gRPC interface does
   not move.
+- **Disable unattended apt upgrades in the CVM image** (issue #71 — only `cvm/`
+  changed, no crate touched) → **no crate version moves at all**; rebuild the
+  image as **`v0.3.0-r2`** (`build-cvm` with `version=v0.3.0`, `image_rev=2`) and
+  tag the source commit `cvm-image-v0.3.0-r2`.
 
 ## Compatibility
 


### PR DESCRIPTION
接 #75。#75 改的是镜像内容，这个 PR 解决「改了镜像但 tapp-server 没变，怎么标识」的问题。

## 问题

CVM 镜像**没有自己的版本号**，它借的是 tapp-server 的 release tag。`version` 一个值同时决定三样东西：

| | 例子 |
|---|---|
| GCP/Ali 镜像名 | `og-tdx-dev-grub-v0-3-0` |
| 参考值路径 | `verifier/reference-values/gcp/grub/v0.3.0/dev.json` |
| AS policy id | `0g-tapp-gcp-grub-v0.3.0-dev` |

但 `cvm/` 下的绝大多数改动（内核、docker 版本 pin、cryptpilot 配置、加固——比如 #71）都会**改变镜像的测量值而二进制一个字节没动**，现有机制表达不了这件事。

拿同一个 tag 重 build 的后果：`register-shared-as.sh` 用**同一个 policy id** 把新参考值推上共享 AS，**所有还在跑旧镜像的节点从那一刻起验不过**。没人动它们，没有任何告警——跟 #71 是同一类事故。

## 改动

`build-cvm` 加一个 `image_rev` 输入。`version` 从此只干一件事：**下载二进制**。所有标识**镜像**的地方改用 `<version>[-r<rev>]`：

```
镜像名      og-tdx-dev-grub-v0-3-0-r2
参考值      verifier/reference-values/gcp/grub/v0.3.0-r2/dev.json
policy id   0g-tapp-gcp-grub-v0.3.0-r2-dev
```

- **rev 1 不加后缀**，所以已经发布的所有标识原样可用，参考值一个都不用迁移。
- rev 在任何昂贵步骤之前就校验必须是正整数（它决定镜像身份，写错会静默产出一个错误标识）。
- rev 进 concurrency group。
- 三个脚本（`gen-reference-values` / `register-shared-as` / `open-refvalues-pr`）都是把 version 当位置参数原样用的，**一行都不用改**。

## 文档

`docs/VERSIONING.md` 原来只有三个制品，镜像根本没被记录。这个 PR 把 CVM image 补成第四个：怎么定版、什么时候 bump rev、**为什么不该改用 bump tapp-server 顶替**（二进制没变，发一个和上个版本字节相同的 release 是对所有读版本号的人撒谎）、`cvm-image-v*` 溯源 tag（`build.yml` 只认 `v*`，`cvm-` 开头匹配不上，不会误发二进制 release），以及运维代价。

`cvm/README.md` 的标识小节也同步了。

## 要提前知道的代价

policy id 变了，**验证方必须用新 id**（`verify-app --policy-ids`，以及 ops 那边写死旧 id 的地方）。这是分开标识必然的代价——比悄悄覆盖、整个 fleet 静默验不过要便宜得多。

## 验证

- YAML 解析通过；`grep` 确认剩余的 `$VERSION` 只在三处取二进制的地方（validate 的 URL 探测、`fetch-inputs.sh`、`TAPP_SERVER_URL`）。
- 命名逻辑按 rev=1 / rev=2 各跑了一遍：
  - `rev=1` → `og-tdx-dev-grub-v0-3-0` / `gcp/grub/v0.3.0/dev.json` / `0g-tapp-gcp-grub-v0.3.0-dev`（**与今天完全一致**）
  - `rev=2` → `og-tdx-dev-grub-v0-3-0-r2` / `gcp/grub/v0.3.0-r2/dev.json` / `0g-tapp-gcp-grub-v0.3.0-r2-dev`
- 未实跑 workflow —— 要一次真实 dispatch 才能端到端确认。

## 建议的落地顺序

1. 先合 #75（镜像内容）
2. 再合本 PR（发布标识）
3. dispatch `build-cvm`，`version=v0.3.0` + `image_rev=2`
4. `git tag cvm-image-v0.3.0-r2` 指向 build 用的 commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
