### PR TITLE
chore(verifier): reference values gcp uki v0.3.0-r2 dev

### DIFF
--- a/verifier/reference-values/gcp/uki/v0.3.0-r2/dev.json
+++ b/verifier/reference-values/gcp/uki/v0.3.0-r2/dev.json
@@ -1,0 +1,5 @@
+{
+  "measurement.uki.SHA-384": [
+    "6e3354a2adaa51344ba5ca71f11eb181982156cffbca7dd0cd38fb01bbbfdd1336414a9a7ac6b0a57233f3e187a0da71"
+  ]
+}


### PR DESCRIPTION
Auto-generated by build-cvm (canonical mode) for gcp/uki v0.3.0-r2/dev. Registered on AS as policy `0g-tapp-gcp-uki-v0.3.0-r2-dev_cpu`.

Opened manually: the build (run 30780289607) pushed this branch but `gh pr create` hit `HTTP 401: Bad credentials` (expired `RELEASE_PAT`) and the script swallowed it, so the step went green with no PR. Fix for the swallowing follows separately.