### PR TITLE
chore(verifier): reference values gcp uki v0.3.0-r2 dev

### DIFF
--- a/verifier/reference-values/gcp/uki/v0.3.0-r2/dev.json
+++ b/verifier/reference-values/gcp/uki/v0.3.0-r2/dev.json
@@ -1,0 +1,5 @@
+{
+  "measurement.uki.SHA-384": [
+    "a8e58d383fd973a1e98418a89fe62cbc4c0e2b926751a8fd55c0e7b53651cdba92be8989fdd6dbd56e5c7ca06e4288bb"
+  ]
+}


### PR DESCRIPTION
Auto-generated by build-cvm (canonical mode) for gcp/uki v0.3.0-r2/dev. Registered on AS as policy `0g-tapp-gcp-uki-v0.3.0-r2-dev_cpu`.