### PR TITLE
ci: authenticate the AS policy write (#82), and stop swallowing refvalues-PR failures

### DIFF
--- a/.github/workflows/build-cvm.yml
+++ b/.github/workflows/build-cvm.yml
@@ -289,6 +289,11 @@ jobs:
           ci/gen-reference-values.sh "out-${{ matrix.env }}.qcow2" "$CLOUD" "$BOOT_FORMAT" "$IMGVER" "${{ matrix.env }}" $OWNER
           cd ..
           verifier/register-shared-as.sh "$CLOUD" "$BOOT_FORMAT" "$IMGVER" "${{ matrix.env }}" $OWNER "$AS_ENDPOINT"
+        env:
+          # Bearer key for the gated AS (issue #82): the hosted deployment allows
+          # AttestationEvaluate/GetAttestationChallenge but requires a key for the policy write.
+          # Unset = unchanged behaviour, and an AS that requires no key ignores the header.
+          AS_WRITE_KEY: ${{ secrets.AS_WRITE_KEY }}
 
       - name: Open PR with the new reference values → dev
         if: ${{ env.PUBLISH == 'true' }}

--- a/cvm/ci/open-refvalues-pr.sh
+++ b/cvm/ci/open-refvalues-pr.sh
@@ -29,5 +29,18 @@ git checkout -B "$BR" origin/dev
 git add "$REF"
 git commit -m "$TITLE" || { echo "no change to commit"; exit 0; }
 git push -u origin "$BR" --force-with-lease
-gh pr create --base dev --head "$BR" --title "$TITLE" --body "$BODY" \
-  || echo "(PR may already exist for $BR)"
+# `gh pr create` fails for two very different reasons and they must not be treated alike:
+# the PR already exists (benign — a rebuild of the same identity), or the credential is
+# broken (expired RELEASE_PAT → "HTTP 401: Bad credentials"). Swallowing both made a dead
+# PAT look like a green build with no PR: the branch was pushed, the reference values were
+# registered on the AS, and nobody noticed the PR was missing. Only the benign case passes.
+if OUT="$(gh pr create --base dev --head "$BR" --title "$TITLE" --body "$BODY" 2>&1)"; then
+  printf '%s\n' "$OUT"
+else
+  printf '%s\n' "$OUT" >&2
+  case "$OUT" in
+    *"already exists"*) echo "(PR already exists for $BR — nothing to do)" ;;
+    *) echo "error: gh pr create failed for $BR (branch IS pushed — check GH_TOKEN/RELEASE_PAT, then open the PR by hand)" >&2
+       exit 1 ;;
+  esac
+fi

--- a/verifier/README.md
+++ b/verifier/README.md
@@ -61,7 +61,12 @@ the policy** at registration time and registered under a per-release/env id:
 ```bash
 ./verifier/register-shared-as.sh v0.1.0 dev            # → policy id 0g-tapp-v0.1.0-dev
 ./verifier/register-shared-as.sh v0.1.0 dev 47.237.201.184:50004
+# gated AS (issue #82): the write needs a key; reads (AttestationEvaluate /
+# GetAttestationChallenge) stay open. Unset = unchanged, and an ungated AS ignores the header.
+AS_WRITE_KEY=<key> ./verifier/register-shared-as.sh v0.1.0 dev
 ```
+
+Keys are issued against the registry's on-chain `admin` signature, expire (30d / 90d / never) and can be revoked. In CI the key comes from the `AS_WRITE_KEY` repository secret. Note what a key does **not** buy: an EAR token records the policy *id* it evaluated, never a hash of the policy, so a write made with a stolen key is as undetectable to verifiers as one made against an open port — the key makes writes attributable and revocable, not verifiable.
 
 Then evaluate (the AS appends the `_cpu` device-class suffix internally):
 

--- a/verifier/register-shared-as.sh
+++ b/verifier/register-shared-as.sh
@@ -17,6 +17,14 @@
 #     owner       optional: OWNER_ADDRESS (0x...); omit for canonical mode
 #     as-endpoint default 47.237.201.184:50004
 #
+# Env:
+#   AS_WRITE_KEY  optional: bearer key for a gated AS (issue #82). The hosted deployment
+#                 keeps the AS on an internal network behind a proxy that allows
+#                 AttestationEvaluate/GetAttestationChallenge but requires a key for this
+#                 write; keys are issued against the registry's on-chain admin signature,
+#                 expire and can be revoked. Unset = today's behaviour, and an AS that
+#                 requires no key ignores the header — so this is safe in both directions.
+#
 # Prereqs: grpcurl, python3, base64; run from the repo (paths are relative to it).
 # =============================================================================
 set -euo pipefail
@@ -100,7 +108,16 @@ trap 'rm -f "$TMP"' EXIT
 B64=$(printf '%s' "$INJECTED" | base64 -w0 | tr '+/' '-_' | tr -d '=')
 python3 -c 'import json,sys; print(json.dumps({"policy_id":sys.argv[1],"policy":sys.argv[2]}))' \
   "${POLICY_ID}_cpu" "$B64" > "$TMP"
-grpcurl -plaintext -import-path "$PROTO_DIR" -proto attestation.proto -d @ \
+# Bearer key for a gated AS. Kept in an array so an unset key adds no argument at all
+# (an empty -H "" would be sent as a malformed header rather than omitted).
+AUTH=()
+if [ -n "${AS_WRITE_KEY:-}" ]; then
+  AUTH=(-H "authorization: Bearer ${AS_WRITE_KEY}")
+  echo "using AS_WRITE_KEY for the write call"
+fi
+# ${AUTH[@]+"${AUTH[@]}"}: expands to nothing when AUTH is empty, and does not trip
+# `set -u` on bash < 4.4 (macOS ships 3.2, where a bare "${AUTH[@]}" is an unbound variable).
+grpcurl -plaintext ${AUTH[@]+"${AUTH[@]}"} -import-path "$PROTO_DIR" -proto attestation.proto -d @ \
   "$AS" attestation.AttestationService/SetAttestationPolicy < "$TMP"
 echo "registered policy ${POLICY_ID} (as ${POLICY_ID}_cpu) on ${AS}"
 echo "verify with: tapp-cli verify-app --app-id <id> --as-endpoint ${AS} --policy-ids ${POLICY_ID}"


### PR DESCRIPTION
Closes #82。两处 CI 凭据问题，按 issue 里给的改法做的。

## 1. `AS_WRITE_KEY`（#82）

`0g-tapp-verifier` 的托管部署把 AS 挪到内网、前面挂代理：`AttestationEvaluate` / `GetAttestationChallenge` 放行，`SetAttestationPolicy` 要 key。部署上线后，CI 的注册步骤会开始 `PermissionDenied`。

- `verifier/register-shared-as.sh`：`AS_WRITE_KEY` 有值时带 `authorization: Bearer …`
- `build-cvm.yml`：从 `secrets.AS_WRITE_KEY` 传进去

**两个方向都兼容**：不设 key = 现在的行为；不要求 key 的 AS 会忽略这个 header。所以合这个 PR 和上线新 AS 的先后顺序无所谓——但按 issue 说的，先合这个更稳。

一个实现细节：header 参数放在数组里、用 `${AUTH[@]+"${AUTH[@]}"}` 展开。空数组直接写 `"${AUTH[@]}"` 在 bash 3.2（macOS）下会因 `set -u` 报 unbound variable，本地跑脚本的人会踩到。

#77 让这件事更要紧：每个镜像 revision 都注册一个新 policy id，注册步骤一坏，**每个新 rev 都没法用 `--policy-ids` 验证**。

## 2. refvalues PR 的静默失败

`open-refvalues-pr.sh` 原来是 `gh pr create || echo "(PR may already exist)"`，把两种性质完全不同的失败当成一回事。结果就是 run `30780289607`：分支推上去了、policy 在 AS 上注册了、**PR 没开**，而 step 是绿的——原因是 `RELEASE_PAT` 过期（`HTTP 401: Bad credentials`）。那次的 PR 是我手工补开的（#79）。

现在只有 `already exists` 放行（同一身份重 build，正常），其它一律让 step 失败，并提示去查什么、以及分支**已经推上去了**（手工开 PR 即可，不用重跑构建）。

## 验证

用 stub 掉的 `grpcurl` / `gh` 跑的：

- 不设 key → 完全没有 `-H`，其余参数一个不少（argc 9）
- 设了 key → 恰好一个 `-H`，其余参数不变（argc 11）
- PR 三种情形：正常 / 已存在 / 401 → 退出码 `0` / `0` / `1`，401 那条打出可操作的错误

真实 AS 的鉴权没法在这儿验——要等托管部署上线后跑一次 `build-cvm` 才知道。

## 没做的部分

#82 里提的两个替代方案都比这个大，本 PR 不涉及：

1. **在 AS 主机上注册**（参考值本来就是以 PR 形式落库的），写接口不暴露公网，CI 不持有任何凭据；
2. **干脆不要 policy**——让 `verify-app` 在本地拿参考值比对启动链（值就在这个仓库里，可以 build 时嵌进去），顺带能给出逐组件结果，新镜像 revision 对验证方零成本。需要发 CLI 新版 + 迁移窗口。

Wilbert 的判断我同意：CI 持有的 key 比开着端口强（可归因、可吊销、会过期），但它仍是共享凭据，而且 EAR token 只记 policy **id**、不记 policy 的哈希——**用偷来的 key 写入，和从开放端口写入一样不可检测**。所以这是止血，不是终局。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
