### PR TITLE
chore(verifier): reference values ali uki v0.3.0-r2 dev

### DIFF
--- a/verifier/reference-values/ali/uki/v0.3.0-r2/dev.json
+++ b/verifier/reference-values/ali/uki/v0.3.0-r2/dev.json
@@ -1,0 +1,5 @@
+{
+  "measurement.uki.SHA-384": [
+    "e53b13435c2709ae90134447661dc13555e17acd7054ada3ae42b2ca32c3f3a7e584224b6088023e7cac8d324da74dc7"
+  ]
+}


### PR DESCRIPTION
Auto-generated by build-cvm (canonical mode) for ali/uki v0.3.0-r2/dev. Registered on AS as policy `0g-tapp-ali-uki-v0.3.0-r2-dev_cpu`.