### PR TITLE
chore(verifier): reference values ali uki v0.3.0-r2 prod

### DIFF
--- a/verifier/reference-values/ali/uki/v0.3.0-r2/prod.json
+++ b/verifier/reference-values/ali/uki/v0.3.0-r2/prod.json
@@ -1,0 +1,5 @@
+{
+  "measurement.uki.SHA-384": [
+    "80cd6add082b0b96c35891ebbacb95faf014ca018aba5dbaaeed9e8f818451bd9d092f2a79bc428a64fb18170e70b6cd"
+  ]
+}


### PR DESCRIPTION
Auto-generated by build-cvm (canonical mode) for ali/uki v0.3.0-r2/prod. Registered on AS as policy `0g-tapp-ali-uki-v0.3.0-r2-prod_cpu`.