### PR TITLE
TLS certificates bound to the TEE: report_data commits to a structure, GetAppTlsCert, socket-only key material

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3009,7 +3009,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
 dependencies = [
  "base64 0.21.7",
- "pem",
+ "pem 1.1.1",
  "ring 0.16.20",
  "serde",
  "serde_json",
@@ -3800,6 +3800,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4357,6 +4367,19 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem 3.0.6",
+ "ring 0.17.14",
+ "rustls-pki-types",
+ "time",
+ "yasna",
 ]
 
 [[package]]
@@ -5582,12 +5605,15 @@ dependencies = [
  "http 1.3.1",
  "hyper 1.7.0",
  "k256",
+ "p256",
  "prost",
  "psutil",
  "rand 0.8.5",
+ "rcgen",
  "regex",
  "reqwest 0.12.23",
  "ring 0.17.14",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -6997,6 +7023,15 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5512,7 +5512,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tapp-cli"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5547,6 +5547,7 @@ dependencies = [
  "http 1.3.1",
  "k256",
  "prost",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -5563,7 +5564,7 @@ dependencies = [
 
 [[package]]
 name = "tapp-server"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [package]
 name = "tapp-server"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 authors = ["TDX TAPP Developers"]
 description = "TDX Trusted Application Platform Service - Rust Implementation"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,9 @@ rand = "0.8.5"
 tower = "0.4"
 http = "1.0"
 hyper = "1.0"
+rcgen = { version = "0.13", default-features = false, features = ["pem", "ring"] }
+p256 = { version = "0.13", features = ["pkcs8", "ecdsa"] }
+rustls-pki-types = "1"
 
 [build-dependencies]
 tonic-build = "0.12"

--- a/proto/tapp_service.proto
+++ b/proto/tapp_service.proto
@@ -223,8 +223,17 @@ message ListAppMeasurementsResponse {
 // Get Evidence Messages
 message GetEvidenceRequest {
   string app_id = 1;  // Application identifier
-                      // The TEE-derived signer EVM address of the app will
-                      // be automatically used as report_data
+
+  // Optional challenge, at most 64 bytes, echoed into the quote's report_data.
+  //
+  // A quote says nothing about when it was produced, so a cached blob looks exactly
+  // like a fresh one. A caller that sends a random value per request can tell them
+  // apart. A caller that fetches once and serves the result to many readers (and
+  // reports it "as of" a timestamp) sends nothing and leaves the field out.
+  //
+  // report_data is sha512 of the `runtime_data` object returned alongside the quote;
+  // see tapp_common::report_data.
+  bytes nonce = 2;
 }
 
 message GetEvidenceResponse {
@@ -239,7 +248,10 @@ message GetEvidenceResponse {
 // Get App Key Messages (replaces GetPubkey)
 message GetAppKeyRequest {
   string app_id = 1;            // Application identifier
-  string key_type = 2;          // Key type: "ethereum", "rsa", "ec"
+  // Only "ethereum" is implemented; empty means "ethereum". Anything else is
+  // refused rather than silently substituted. "rsa"/"ec" were advertised here for a
+  // long time and never existed.
+  string key_type = 2;
   bytes additional_data = 3;    // Additional binding data
   string kbs_resource_uri = 4;  // KBS resource URI for key material
   bool x25519 = 5;              // Use X25519 key pair
@@ -261,7 +273,7 @@ message GetAppKeyResponse {
 // Get App Secret Key Messages (local access only)
 message GetAppSecretKeyRequest {
   string app_id = 1;    // Application identifier
-  string key_type = 2;  // Key type: "ethereum", "rsa", "ec"
+  string key_type = 2;  // Only "ethereum" is implemented; empty means "ethereum"
   bool x25519 = 3;      // Use X25519 key pair
 }
 

--- a/proto/tapp_service.proto
+++ b/proto/tapp_service.proto
@@ -26,6 +26,11 @@ service TappService {
   // Get application secret key (private key) - local access only
   rpc GetAppSecretKey(GetAppSecretKeyRequest) returns (GetAppSecretKeyResponse);
 
+  // Get the app's TLS key and certificate - local access only.
+  // The key is derived from KMS, so it is the same on every restart and on every node
+  // of the app; the app just writes two PEM files and points its server at them.
+  rpc GetAppTlsCert(GetAppTlsCertRequest) returns (GetAppTlsCertResponse);
+
   // Get application information
   rpc GetAppInfo(GetAppInfoRequest) returns (GetAppInfoResponse);
 
@@ -268,6 +273,35 @@ message GetAppKeyResponse {
   bytes x25519_public_key = 5;  // 32-byte X25519 public key
   // Key provenance
   string key_source = 6;  // Source: "kbs", "in-memory"
+}
+
+// Get App TLS Cert Messages (local access only — carries a private key)
+message GetAppTlsCertRequest {
+  string app_id = 1;  // Application identifier
+}
+
+message GetAppTlsCertResponse {
+  bool success = 1;
+  string message = 2;
+
+  // The two files an ordinary TLS server wants. No crypto work left for the app.
+  string key_pem = 3;
+  string cert_pem = 4;
+
+  // "ca" when a CA signed it, "self-signed" when none is configured. Self-signed is
+  // not a lesser certificate here: what a verifier checks is the public key against
+  // the quote, not the issuer. The issuer matters only to clients that will not do
+  // that check — browsers, anything using a system trust store.
+  string issuer = 5;
+
+  // Always present, so the certificate can be reissued by whatever authority the
+  // deployer prefers (Let's Encrypt, their own CA) without asking for the key again.
+  string csr_pem = 6;
+
+  // sha256 of the SubjectPublicKeyInfo, hex. This is the value the quote's report_data
+  // commits to, so a verifier compares this against the key it was handed during the
+  // handshake. Returned here to save every caller re-deriving it.
+  string public_key_sha256 = 7;
 }
 
 // Get App Secret Key Messages (local access only)

--- a/proto/tapp_service.proto
+++ b/proto/tapp_service.proto
@@ -27,8 +27,9 @@ service TappService {
   rpc GetAppSecretKey(GetAppSecretKeyRequest) returns (GetAppSecretKeyResponse);
 
   // Get the app's TLS key and certificate - local access only.
-  // The key is derived from KMS, so it is the same on every restart and on every node
-  // of the app; the app just writes two PEM files and points its server at them.
+  // The app writes two PEM files and points its server at them; no crypto work is left
+  // to it. Where the key comes from is a deployment choice — see key_source in the
+  // response, which decides whether the public key survives a restart.
   rpc GetAppTlsCert(GetAppTlsCertRequest) returns (GetAppTlsCertResponse);
 
   // Get application information
@@ -302,6 +303,12 @@ message GetAppTlsCertResponse {
   // commits to, so a verifier compares this against the key it was handed during the
   // handshake. Returned here to save every caller re-deriving it.
   string public_key_sha256 = 7;
+
+  // "local" or "kms" — where the private key came from. This decides whether the public
+  // key survives a restart, so a client choosing to pin it needs to know: "local" is
+  // bound to this instance and changes when it restarts, "kms" is stable and shared by
+  // every node of the app.
+  string key_source = 8;
 }
 
 // Get App Secret Key Messages (local access only)

--- a/proto/tapp_service.proto
+++ b/proto/tapp_service.proto
@@ -704,6 +704,16 @@ message ClaimConfigRequest {
   // When provided, the KMS client is initialized on this call (no config.toml
   // [kbs] section needed). Ignored if KBS was already configured at startup.
   repeated string kbs_node_urls = 3;
+
+  // Optional: where app TLS private keys come from — "local" (default) or "kms".
+  //
+  // Here rather than in config.toml for the same reason the owner is: config.toml
+  // lives in the CVM image, so a field there means a separate image and a separate
+  // set of reference values per choice. Claimed instead, the image stays generic and
+  // the choice becomes a measured fact a verifier can read out of the event log —
+  // which matters, because it decides whether the attested public key survives a
+  // restart.
+  string tls_key_source = 4;
 }
 
 message ClaimConfigResponse {

--- a/src/auth_layer.rs
+++ b/src/auth_layer.rs
@@ -114,6 +114,35 @@ where
                 return inner.call(req).await;
             }
 
+            // Socket-only methods: no signature, but the request must have arrived on the
+            // Unix socket. tonic records connect-info per listener, and a TCP connection
+            // always carries a peer address while a Unix one never does — so this is the
+            // transport itself answering, not a judgement about the address.
+            if method_permission == MethodPermission::LocalOnly {
+                let over_tcp = req
+                    .extensions()
+                    .get::<tonic::transport::server::TcpConnectInfo>()
+                    .and_then(|i| i.remote_addr())
+                    .is_some();
+                if over_tcp {
+                    warn!(
+                        method = %method_name,
+                        event = "AUTH_NOT_LOCAL",
+                        "Refused: this method hands over key material and is served only on \
+                         the Unix socket"
+                    );
+                    let response = Status::permission_denied(format!(
+                        "{} is served only on the tapp Unix socket; mount it into the \
+                         container instead of connecting over TCP",
+                        method_name
+                    ))
+                    .into_http();
+                    return Ok(response);
+                }
+                debug!(method = %method_name, "Local socket method, no auth required");
+                return inner.call(req).await;
+            }
+
             // Extract headers needed for validation
             let signature = req
                 .headers()
@@ -197,6 +226,15 @@ pub struct SignerAddress(pub String);
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum MethodPermission {
     Public,        // No auth required
+    /// Reachable only over the Unix socket, never over TCP. No signature either — the
+    /// caller is a container inside this CVM asking for key material, and it has no key
+    /// to sign with; it is calling in order to obtain one.
+    ///
+    /// The socket is the control, and it is a precise one: `main.rs` creates it 0600
+    /// inside a 0700 directory, so reaching it means holding a file descriptor the
+    /// filesystem granted. The check it replaces asked whether the source IP was private
+    /// — which is true of every machine in the same VPC, not just this one.
+    LocalOnly,
     Authenticated, // Any valid signature (permission decided in the handler)
     OwnerOnly,     // Only tapp owner
     Whitelist,     // Owner or whitelisted users
@@ -217,16 +255,14 @@ fn get_method_permission(method_name: &str) -> MethodPermission {
 /// tell "explicitly OwnerOnly" from "nobody decided", which the return type alone cannot.
 fn classify(method_name: &str) -> Option<MethodPermission> {
     Some(match method_name {
-        // No signature required. For most of these there is nothing to protect — the
-        // answer is public. GetAppSecretKey, GetSecretResource and GetAppTlsCert are the
-        // exceptions: they hand over key material, and "public" here means *the signature
-        // is not the control*. Their caller is an app container inside this CVM, which has
-        // no key to sign with — it is calling in order to obtain one. What guards them is
-        // the locality check in each handler, which refuses anything that is not
-        // localhost, the Docker network, or the Unix socket.
+        // Nothing to protect — the answer is public either way.
         "GetEvidence" | "GetAppKey" | "GetAppInfo" | "ListApps" | "GetTaskStatus"
-        | "GetServiceStatus" | "GetAppSecretKey" | "GetTappInfo" | "GetSecretResource"
-        | "GetAppTlsCert" => MethodPermission::Public,
+        | "GetServiceStatus" | "GetTappInfo" => MethodPermission::Public,
+
+        // Hand over key material. Socket only.
+        "GetAppSecretKey" | "GetSecretResource" | "GetAppTlsCert" => {
+            MethodPermission::LocalOnly
+        }
 
         // Signature required, but no permission level: while the tapp is
         // unclaimed anybody may claim (first-come-first-served); once claimed
@@ -301,6 +337,9 @@ mod tests {
 fn is_authorized(required: &MethodPermission, actual: &Permission) -> bool {
     match required {
         MethodPermission::Public => true,
+        // Never reaches here — the middleware answers socket-only methods before any
+        // signature exists. Returning false keeps it that way if the order ever changes.
+        MethodPermission::LocalOnly => false,
         MethodPermission::Authenticated => true, // signature already validated
         MethodPermission::OwnerOnly => *actual == Permission::Owner,
         MethodPermission::Whitelist => {

--- a/src/auth_layer.rs
+++ b/src/auth_layer.rs
@@ -202,14 +202,31 @@ enum MethodPermission {
     Whitelist,     // Owner or whitelisted users
 }
 
-/// Get permission requirement for a method
+/// Get permission requirement for a method.
+///
+/// An unclassified method gets OwnerOnly, which fails closed — a new RPC is unreachable
+/// until someone decides what guards it, rather than quietly inheriting the weakest rule.
 fn get_method_permission(method_name: &str) -> MethodPermission {
-    match method_name {
-        // Public methods (no authentication required)
+    classify(method_name).unwrap_or_else(|| {
+        warn!(method = %method_name, "Unknown method, defaulting to OwnerOnly");
+        MethodPermission::OwnerOnly
+    })
+}
+
+/// `None` means the method is not listed here. Split out from the fallback so a test can
+/// tell "explicitly OwnerOnly" from "nobody decided", which the return type alone cannot.
+fn classify(method_name: &str) -> Option<MethodPermission> {
+    Some(match method_name {
+        // No signature required. For most of these there is nothing to protect — the
+        // answer is public. GetAppSecretKey, GetSecretResource and GetAppTlsCert are the
+        // exceptions: they hand over key material, and "public" here means *the signature
+        // is not the control*. Their caller is an app container inside this CVM, which has
+        // no key to sign with — it is calling in order to obtain one. What guards them is
+        // the locality check in each handler, which refuses anything that is not
+        // localhost, the Docker network, or the Unix socket.
         "GetEvidence" | "GetAppKey" | "GetAppInfo" | "ListApps" | "GetTaskStatus"
-        | "GetServiceStatus" | "GetAppSecretKey" | "GetTappInfo" | "GetSecretResource" => {
-            MethodPermission::Public
-        }
+        | "GetServiceStatus" | "GetAppSecretKey" | "GetTappInfo" | "GetSecretResource"
+        | "GetAppTlsCert" => MethodPermission::Public,
 
         // Signature required, but no permission level: while the tapp is
         // unclaimed anybody may claim (first-come-first-served); once claimed
@@ -224,17 +241,59 @@ fn get_method_permission(method_name: &str) -> MethodPermission {
         | "ListWhitelist"
         | "ListAllOwnerships"
         | "StopService"
-        | "StartService" => MethodPermission::OwnerOnly,
+        | "StartService"
+        // These two were never listed and reached OwnerOnly through the fallback. Stated
+        // explicitly to keep the behaviour they already had — ListAppMeasurements is a
+        // deprecated stub that errors either way, and tapp-cli already signs for
+        // GetAppContainerStatus.
+        | "ListAppMeasurements"
+        | "GetAppContainerStatus" => MethodPermission::OwnerOnly,
 
         // Owner or whitelist methods
         "GetServiceLogs" | "GetAppLogs" | "GetAppOwnership" | "WithdrawBalance" | "DockerLogin"
         | "DockerLogout" | "PruneImages" => MethodPermission::Whitelist,
 
-        // Default: require owner permission
-        _ => {
-            warn!(method = %method_name, "Unknown method, defaulting to OwnerOnly");
-            MethodPermission::OwnerOnly
+        _ => return None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every RPC the service declares must be classified on purpose.
+    ///
+    /// The fallback is OwnerOnly, so forgetting one does not open a hole — it makes the
+    /// RPC unusable by the callers that need it, which is how GetAppTlsCert first failed:
+    /// an app container has no key to sign with, so it got "Missing signature" from a rule
+    /// nobody had chosen. Reading the method list out of the proto rather than repeating it
+    /// here is the point; a list maintained by hand would drift the same way.
+    #[test]
+    fn every_rpc_in_the_proto_has_a_deliberate_permission() {
+        let proto = include_str!("../proto/tapp_service.proto");
+        let mut unclassified = Vec::new();
+        let mut seen = 0usize;
+        for line in proto.lines() {
+            let line = line.trim();
+            let Some(rest) = line.strip_prefix("rpc ") else {
+                continue;
+            };
+            let name = rest.split('(').next().unwrap_or("").trim();
+            if name.is_empty() {
+                continue;
+            }
+            seen += 1;
+            if classify(name).is_none() {
+                unclassified.push(name.to_string());
+            }
         }
+        assert!(seen > 20, "parsed only {} rpcs — the proto layout changed", seen);
+        assert!(
+            unclassified.is_empty(),
+            "these RPCs fall through to the OwnerOnly default; classify them in \
+             get_method_permission: {:?}",
+            unclassified
+        );
     }
 }
 

--- a/src/boot/mod.rs
+++ b/src/boot/mod.rs
@@ -552,6 +552,7 @@ enable_eventlog = true
         &self,
         request: GetEvidenceRequest,
         signer_eth_address: &[u8],
+        tls_public_key: Option<String>,
     ) -> TappResult<GetEvidenceResponse> {
         // Get app_id from request
         let app_id = request.app_id;
@@ -588,8 +589,9 @@ enable_eventlog = true
         // the caller's challenge (and later the app's TLS key) fit alongside it. The
         // structure travels with the quote — a quote on its own no longer names its
         // signer. See tapp_common::report_data.
-        let runtime_data =
+        let mut runtime_data =
             crate::report_data::RuntimeData::new(signer_eth_address, &request.nonce)?;
+        runtime_data.tls_public_key = tls_public_key.unwrap_or_default();
         let (runtime_data_bytes, report_data) = runtime_data.seal()?;
 
         info!(

--- a/src/boot/mod.rs
+++ b/src/boot/mod.rs
@@ -14,6 +14,41 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 use tracing::{error, info, warn};
 
+/// Put the hashed bytes into the evidence next to `quote` and `cc_eventlog`, so a
+/// verifier receives everything it needs as one object and never has to be told
+/// separately what `report_data` committed to.
+///
+/// The attester's output is JSON for every TEE we support, but if it ever isn't the
+/// evidence is passed through untouched: losing the field degrades a verifier to the
+/// old signer-only reading, whereas returning a mangled blob would break it outright.
+fn attach_runtime_data(evidence: Vec<u8>, runtime_data: &[u8]) -> Vec<u8> {
+    use base64::Engine;
+    let mut parsed: serde_json::Value = match serde_json::from_slice(&evidence) {
+        Ok(v) => v,
+        Err(e) => {
+            warn!(error = %e, "evidence is not JSON; runtime_data not attached");
+            return evidence;
+        }
+    };
+    let Some(obj) = parsed.as_object_mut() else {
+        warn!("evidence is not a JSON object; runtime_data not attached");
+        return evidence;
+    };
+    obj.insert(
+        crate::report_data::EVIDENCE_FIELD.to_string(),
+        serde_json::Value::String(
+            base64::engine::general_purpose::STANDARD.encode(runtime_data),
+        ),
+    );
+    match serde_json::to_vec(&parsed) {
+        Ok(v) => v,
+        Err(e) => {
+            error!(error = %e, "re-serialising evidence failed; returning original");
+            evidence
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct AppComposeContent {
     pub hash: String,
@@ -538,28 +573,35 @@ enable_eventlog = true
             }
         }
 
-        if signer_eth_address.len() != 20 {
+        if request.nonce.len() > crate::report_data::MAX_NONCE_LEN {
             return Err(TappError::InvalidParameter {
-                field: "signer_eth_address".to_string(),
+                field: "nonce".to_string(),
                 reason: format!(
-                    "Invalid signer address length: expected 20 bytes, got {}",
-                    signer_eth_address.len()
+                    "nonce must be at most {} bytes, got {}",
+                    crate::report_data::MAX_NONCE_LEN,
+                    request.nonce.len()
                 ),
             });
         }
 
-        // Prepare report_data: pad signer EVM address (20 bytes) to 64 bytes
-        let mut report_data = vec![0u8; 64];
-        report_data[..signer_eth_address.len()].copy_from_slice(signer_eth_address);
+        // report_data commits to a small structure rather than to the signer alone, so
+        // the caller's challenge (and later the app's TLS key) fit alongside it. The
+        // structure travels with the quote — a quote on its own no longer names its
+        // signer. See tapp_common::report_data.
+        let runtime_data =
+            crate::report_data::RuntimeData::new(signer_eth_address, &request.nonce)?;
+        let (runtime_data_bytes, report_data) = runtime_data.seal()?;
 
         info!(
             app_id = %app_id,
-            signer = %format!("0x{}", hex::encode(signer_eth_address)),
+            signer = %runtime_data.signer,
+            nonce_len = request.nonce.len(),
             report_data = %hex::encode(&report_data),
-            "Generating evidence with app signer as report_data"
+            "Generating evidence"
         );
 
         let evidence = self.measurement_service.get_evidence(&report_data).await?;
+        let evidence = attach_runtime_data(evidence, &runtime_data_bytes);
         let tee_type = self.measurement_service.get_tee_type().await;
         Ok(GetEvidenceResponse {
             success: true,

--- a/src/config.rs
+++ b/src/config.rs
@@ -69,6 +69,44 @@ impl TappConfig {
     }
 }
 
+/// Where an app's TLS private key comes from. The two are not better and worse — they
+/// trade the same thing in opposite directions.
+///
+/// **`Local`** derives it from the app's own signer, which is generated inside this CVM and
+/// never leaves it. The key is therefore bound to *this instance*: a verifier that compares
+/// it against `report_data` learns "the endpoint I am talking to is this TEE", the strongest
+/// statement available. Nothing external is involved — no KMS, no on-chain registration — so
+/// it works from first boot. The cost is that the signer is regenerated on every restart, so
+/// the key changes with it: certificate pinning breaks, Certificate Transparency monitoring
+/// sees churn instead of signal, and an ACME certificate would need reissuing every restart
+/// against a rate limit.
+///
+/// **`Kms`** derives it from `(app_id, material)` at the KMS cluster, so it is stable across
+/// restarts and identical on every node of the app. That is what makes pinning, transparency
+/// monitoring and normal certificate renewal work. The cost is that the key exists outside
+/// this CVM — the answering KMS node reconstructs it — and any registered signer of the app
+/// can obtain it, so the statement weakens to "some TEE of this app". It also needs the app
+/// registered on chain and the cluster reachable.
+///
+/// Local is the default because it always works and asks nothing of the deployer; stability
+/// is the thing you opt into once something needs it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum TlsKeySource {
+    #[default]
+    Local,
+    Kms,
+}
+
+impl TlsKeySource {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            TlsKeySource::Local => "local",
+            TlsKeySource::Kms => "kms",
+        }
+    }
+}
+
 /// Server configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ServerConfig {
@@ -104,6 +142,10 @@ pub struct ServerConfig {
 
     /// TLS private key path (if TLS enabled)
     pub tls_key_path: Option<PathBuf>,
+
+    /// Where an app's TLS private key comes from. See [`TlsKeySource`].
+    #[serde(default)]
+    pub tls_key_source: TlsKeySource,
 
     /// Certificate authority for app TLS certificates, e.g. `http://ca:8080`.
     ///
@@ -269,6 +311,7 @@ impl Default for ServerConfig {
             tls_enabled: false,
             tls_cert_path: None,
             tls_key_path: None,
+            tls_key_source: TlsKeySource::default(),
             ca_url: None,
             permission: None,
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -105,6 +105,14 @@ pub struct ServerConfig {
     /// TLS private key path (if TLS enabled)
     pub tls_key_path: Option<PathBuf>,
 
+    /// Certificate authority for app TLS certificates, e.g. `http://ca:8080`.
+    ///
+    /// Optional on purpose. Unset, `GetAppTlsCert` self-signs, which is enough for any
+    /// client that checks the public key against the attestation — the issuer is
+    /// irrelevant to that check. A CA is what makes the same certificate acceptable to
+    /// clients that will not do it, such as browsers driving off a trust store.
+    pub ca_url: Option<String>,
+
     /// Permission configuration for signature-based authentication
     #[serde(default)]
     pub permission: Option<PermissionConfig>,
@@ -261,6 +269,7 @@ impl Default for ServerConfig {
             tls_enabled: false,
             tls_cert_path: None,
             tls_key_path: None,
+            ca_url: None,
             permission: None,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,15 @@ impl TappServiceImpl {
             )
         })?;
 
+        // Create-if-missing first. `get_private_key` below only reads the cache, so without
+        // this a KMS request fails outright when it is the app's very first call — which is
+        // exactly what happens when an app asks for its TLS certificate before anything
+        // else has touched its key.
+        self.app_key_service
+            .get_app_key(app_id, "ethereum", false)
+            .await
+            .map_err(|e| Status::internal(format!("Failed to create app key: {}", e)))?;
+
         // Get in-memory key pair: private key for signing + decryption, pubkey for KMS encryption target
         let private_key = self
             .app_key_service

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,8 @@ pub struct ClaimedRuntimeConfig {
     pub chain_rpc_url: String,
     pub chain_contract_address: String,
     pub kbs_node_urls: Vec<String>,
+    /// Empty means "not claimed" — fall back to config.toml, which is the pre-baked mode.
+    pub tls_key_source: String,
 }
 
 pub struct TappServiceImpl {
@@ -149,7 +151,18 @@ impl TappServiceImpl {
             return Ok(id.clone());
         }
 
-        let source = self.config.server.tls_key_source;
+        // Claimed value wins over the pre-baked one, same as chain and KBS config.
+        let source = match self
+            .claimed_runtime_config
+            .read()
+            .await
+            .tls_key_source
+            .as_str()
+        {
+            "kms" => config::TlsKeySource::Kms,
+            "local" => config::TlsKeySource::Local,
+            _ => self.config.server.tls_key_source,
+        };
         let secret = match source {
             config::TlsKeySource::Local => {
                 // Create-if-missing, then derive from the signer. `get_private_key` only
@@ -387,6 +400,7 @@ impl TappServiceImpl {
             chain_rpc_url: config.chain.as_ref().map(|c| c.rpc_url.clone()).unwrap_or_default(),
             chain_contract_address: config.chain.as_ref().map(|c| c.contract_address.clone()).unwrap_or_default(),
             kbs_node_urls: config.kbs.as_ref().map(|k| k.node_urls.clone()).unwrap_or_default(),
+            tls_key_source: config.server.tls_key_source.as_str().to_string(),
         }));
 
         info!("All TAPP service components initialized successfully");
@@ -1305,6 +1319,22 @@ impl TappService for TappServiceImpl {
             Status::already_exists(format!("Tapp already owned by {}", current))
         })?;
 
+        // Reject an unknown value rather than falling back: this decides whether the
+        // attested TLS key survives a restart, and a typo silently becoming "local" is
+        // exactly the kind of thing nobody notices until a pin breaks.
+        let tls_key_source = match req.tls_key_source.as_str() {
+            "" => self.config.server.tls_key_source,
+            "local" => config::TlsKeySource::Local,
+            "kms" => config::TlsKeySource::Kms,
+            other => {
+                pm.rollback_claim().await;
+                return Err(Status::invalid_argument(format!(
+                    "tls_key_source must be \"local\" or \"kms\", got {:?}",
+                    other
+                )));
+            }
+        };
+
         // Extend runtime measurement — includes the full config so verifiers
         // see owner + chain + kbs in one event. On failure the claim is rolled
         // back so the tapp stays claimable.
@@ -1315,6 +1345,7 @@ impl TappService for TappServiceImpl {
             "chain_rpc_url": req.chain_rpc_url,
             "chain_contract_address": req.chain_contract_address,
             "kbs_node_urls": req.kbs_node_urls,
+            "tls_key_source": tls_key_source.as_str(),
             "timestamp": timestamp
         })
         .to_string();
@@ -1339,6 +1370,7 @@ impl TappService for TappServiceImpl {
             chain_rpc_url: req.chain_rpc_url.clone(),
             chain_contract_address: req.chain_contract_address.clone(),
             kbs_node_urls: req.kbs_node_urls.clone(),
+            tls_key_source: tls_key_source.as_str().to_string(),
         };
 
         // Initialize or replace KMS client with the claimed kbs_node_urls.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,6 @@ pub use boot::BootService;
 pub use config::TappConfig;
 pub use tapp_common::error::{TappError, TappResult};
 use std::collections::HashMap;
-use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
 pub use task_manager::TaskStatus;
 use tokio::sync::Mutex;
@@ -290,77 +289,6 @@ impl TappServiceImpl {
         {
             tracing::error!("Failed to extend measurement for get_secret_resource: {}", e);
         }
-    }
-
-    /// Check if an IP address is allowed for local access
-    /// Allows:
-    /// - Localhost (127.0.0.1, ::1)
-    /// - Docker bridge networks (172.16.0.0/12)
-    /// - Private networks (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16)
-    fn is_allowed_local_access(ip: IpAddr) -> bool {
-        use std::net::IpAddr;
-
-        match ip {
-            IpAddr::V4(ipv4) => {
-                // Localhost: 127.0.0.1
-                if ipv4.is_loopback() {
-                    return true;
-                }
-
-                // Private networks (includes Docker networks)
-                // 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16
-                if ipv4.is_private() {
-                    return true;
-                }
-
-                false
-            }
-            IpAddr::V6(ipv6) => {
-                // Localhost: ::1
-                ipv6.is_loopback()
-            }
-        }
-    }
-
-    /// Determine the source type for logging
-    /// Get source type description for logging
-    fn get_source_type(ip: IpAddr) -> &'static str {
-        use std::net::IpAddr;
-
-        match ip {
-            IpAddr::V4(ipv4) => {
-                if ipv4.is_loopback() {
-                    "localhost"
-                } else if Self::is_docker_bridge_network(ipv4) {
-                    "docker-bridge"
-                } else if Self::is_docker_custom_network(ipv4) {
-                    "docker-custom"
-                } else if ipv4.is_private() {
-                    "private-network"
-                } else {
-                    "public-network"
-                }
-            }
-            IpAddr::V6(ipv6) => {
-                if ipv6.is_loopback() {
-                    "localhost-ipv6"
-                } else {
-                    "ipv6-network"
-                }
-            }
-        }
-    }
-
-    /// Check if IP is from Docker default bridge network (172.17.0.0/16)
-    fn is_docker_bridge_network(ip: Ipv4Addr) -> bool {
-        let octets = ip.octets();
-        octets[0] == 172 && octets[1] == 17
-    }
-
-    /// Check if IP is from Docker custom networks (172.18-31.0.0/16)
-    fn is_docker_custom_network(ip: Ipv4Addr) -> bool {
-        let octets = ip.octets();
-        octets[0] == 172 && (18..=31).contains(&octets[1])
     }
 
     pub async fn new(
@@ -715,23 +643,8 @@ impl TappService for TappServiceImpl {
     ) -> Result<Response<GetAppTlsCertResponse>, Status> {
         info!("Calling GetAppTlsCert");
 
-        // SECURITY: this hands over a private key, so it is restricted exactly like
-        // GetAppSecretKey — same host only. The app container is inside this CVM, so the
-        // key does not cross the enclave boundary.
-        let remote_addr = request.remote_addr();
-        let allowed = remote_addr
-            .map(|a| Self::is_allowed_local_access(a.ip()))
-            .unwrap_or(true); // Unix socket
-        if !allowed {
-            tracing::error!(
-                remote_addr = ?remote_addr,
-                event = "TLS_CERT_ACCESS_DENIED",
-                "Rejected GetAppTlsCert from a non-local address"
-            );
-            return Err(Status::permission_denied(
-                "GetAppTlsCert can only be called from localhost or same-host Docker containers",
-            ));
-        }
+        // Reachability is the control and AuthLayer enforces it: this method is served
+        // only on the Unix socket. See MethodPermission::LocalOnly.
 
         let req = request.into_inner();
         if req.app_id.is_empty() {
@@ -771,32 +684,10 @@ impl TappService for TappServiceImpl {
     ) -> Result<Response<GetAppSecretKeyResponse>, Status> {
         info!("Calling GetAppSecretKey");
         debug!("Request: {:?}", request);
-        // SECURITY: Extract remote address BEFORE consuming request
+        // Reachability is the control and AuthLayer enforces it: this method is served
+        // only on the Unix socket. See MethodPermission::LocalOnly.
         let remote_addr = request.remote_addr();
-
-        // SECURITY: Validate that the request is from localhost or Docker network
-        let (is_allowed, source_type) = if let Some(addr) = remote_addr {
-            let ip = addr.ip();
-            let allowed = Self::is_allowed_local_access(ip);
-            let source = Self::get_source_type(ip);
-            (allowed, source)
-        } else {
-            // No remote address (e.g., Unix socket) - allow
-            (true, "unix-socket")
-        };
-
-        if !is_allowed {
-            tracing::error!(
-                remote_addr = ?remote_addr,
-                event = "SECRET_KEY_ACCESS_DENIED",
-                reason = "not in allowed network range",
-                "Rejected GetAppSecretKey request from non-allowed address"
-            );
-
-            return Err(Status::permission_denied(
-                "GetAppSecretKey can only be called from localhost or same-host Docker containers",
-            ));
-        }
+        let source_type = "unix-socket";
 
         // Get signer address from signature (handled by AuthLayer)
         // let signer = auth_layer::get_signer_address(&request);
@@ -1973,16 +1864,8 @@ impl TappService for TappServiceImpl {
     ) -> Result<Response<GetSecretResourceResponse>, Status> {
         info!("Calling GetSecretResource");
 
-        // SECURITY: local access only
-        let remote_addr = request.remote_addr();
-        let allowed = remote_addr
-            .map(|a| Self::is_allowed_local_access(a.ip()))
-            .unwrap_or(true); // Unix socket
-        if !allowed {
-            return Err(Status::permission_denied(
-                "GetSecretResource can only be called from localhost or same-host Docker containers",
-            ));
-        }
+        // Reachability is the control and AuthLayer enforces it: this method is served
+        // only on the Unix socket. See MethodPermission::LocalOnly.
 
         let req = request.into_inner();
         let app_id = &req.app_id;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -457,7 +457,7 @@ impl TappService for TappServiceImpl {
         debug!("Request: {:?}", request);
         let signer = auth_layer::get_signer_address(&request);
         let req_inner = request.into_inner();
-        // let app_id = req_inner.app_id.clone();
+        let app_id = req_inner.app_id.clone();
 
         // Get deployer address (signer EVM address)
         // If no signer (auth disabled), use a default placeholder
@@ -471,6 +471,32 @@ impl TappService for TappServiceImpl {
             .clone()
             .start_app(req_inner, deployer.clone())
             .await?;
+
+        // Derive the app's TLS identity now rather than waiting for it to be asked for.
+        //
+        // The rule is one sentence — the key exists as soon as the app runs — and it holds
+        // for both key sources, which matters: a verifier reading "no TLS key" out of
+        // evidence must not have to wonder whether it means "none" or "not fetched yet".
+        //
+        // Waiting is not an unlucky race but the normal case. Deployment goes start → register
+        // on chain → the app fetches its certificate, and a registry event is exactly what
+        // makes tappscan re-verify — so it would fetch evidence in the gap, record "no TLS
+        // key", and keep saying so until its hourly backstop.
+        //
+        // Doing it here rather than in GetEvidence keeps it behind the owner's signature.
+        // GetEvidence is unauthenticated, and deriving there would let anyone drive KMS
+        // traffic, and mint keys for apps that never wanted one.
+        //
+        // Best effort: a KMS-sourced key needs the app registered on chain and the cluster
+        // reachable, neither of which is true on a first deploy. Failing here would fail a
+        // start that has already succeeded, so it is logged and the lazy path picks it up.
+        if let Err(e) = self.tls_identity(&app_id).await {
+            info!(
+                app_id = %app_id,
+                error = %e,
+                "TLS identity not derived at start; it will be derived when first requested"
+            );
+        }
 
         // Record ownership if permission management is enabled
         // if let Some(pm) = &self.permission_manager {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,14 +19,17 @@ pub mod permission;
 pub mod service_monitor;
 pub mod signature_auth;
 pub mod task_manager;
+pub mod tls_cert;
 pub mod utils;
 
 pub use boot::BootService;
 pub use config::TappConfig;
 pub use tapp_common::error::{TappError, TappResult};
+use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
 pub use task_manager::TaskStatus;
+use tokio::sync::Mutex;
 use tonic::{Request, Response, Status};
 use tracing::{debug, error, info};
 
@@ -64,9 +67,116 @@ pub struct TappServiceImpl {
     pub measurement_service: Arc<measurement_service::MeasurementService>,
     /// Runtime config set by ClaimConfig or establish_owner_at_startup.
     pub claimed_runtime_config: Arc<tokio::sync::RwLock<ClaimedRuntimeConfig>>,
+    /// Per-app TLS identity, derived on first use. Same lifetime as the app key cache:
+    /// the key itself is deterministic, so a restart re-derives the identical one.
+    pub tls_identities: Arc<Mutex<HashMap<String, Arc<tls_cert::TlsIdentity>>>>,
 }
 
 impl TappServiceImpl {
+    /// Fetch a KMS-derived secret for `app_id` under the `material` namespace.
+    ///
+    /// Shared by `GetSecretResource` and by TLS key derivation, so both authenticate to
+    /// KMS the same way — with the app's own signer — and neither can drift into a second
+    /// convention.
+    async fn kms_derive(&self, app_id: &str, material: &str) -> Result<Vec<u8>, Status> {
+        let kms_guard = self.kms_client.read().await;
+        let kms = kms_guard.as_ref().ok_or_else(|| {
+            Status::failed_precondition(
+                "KMS not configured — set [kbs] node_urls in config.toml or call claim-config \
+                 with --kbs-urls",
+            )
+        })?;
+
+        // Get in-memory key pair: private key for signing + decryption, pubkey for KMS encryption target
+        let private_key = self
+            .app_key_service
+            .get_private_key(app_id)
+            .await
+            .map_err(|e| Status::internal(format!("Failed to get app key: {}", e)))?;
+
+        let (_, secp256k1_pubkey_64, _) = self
+            .app_key_service
+            .get_public_key(app_id)
+            .await
+            .map_err(|e| Status::internal(format!("Failed to get app public key: {}", e)))?;
+
+        // ecies expects uncompressed secp256k1 pubkey: 0x04 || 64 bytes
+        let pubkey_uncompressed = [&[0x04u8], secp256k1_pubkey_64.as_slice()].concat();
+        let pubkey_hex = hex::encode(&pubkey_uncompressed);
+
+        // Sign KMS request: EIP-191 personal_sign over "GetSecretResource:{timestamp}"
+        // (KMS server verifies via ecrecover, so signature must be 65-byte r||s||v).
+        let timestamp = chrono::Utc::now().timestamp();
+        let message = signature_auth::build_sign_message("GetSecretResource", timestamp);
+        let signature = app_key::sign_message_eip191(&private_key, message.as_bytes())
+            .map_err(|e| Status::internal(format!("Failed to sign KMS request: {}", e)))?;
+        let signature_hex = hex::encode(&signature);
+
+        // Call KMS cluster → get ECIES-encrypted app key. `material` is opaque
+        // derivation material forwarded verbatim (empty = omitted, derives
+        // purely from the app_id namespace as before) — see issue #33.
+        let encrypted = kms
+            .get_encrypted_secret(app_id, timestamp, &pubkey_hex, &signature_hex, material)
+            .await
+            .map_err(|e| Status::unavailable(format!("KMS request failed: {}", e)))?;
+
+        // Decrypt with our private key
+        ecies::decrypt(&private_key, &encrypted)
+            .map_err(|e| Status::internal(format!("Failed to decrypt KMS secret: {}", e)))
+    }
+
+    /// The app's TLS identity, derived on first use and kept for the process lifetime.
+    ///
+    /// Cached because the certificate is asked for on every app start and on every
+    /// renewal check, while the underlying key never changes — and because `GetEvidence`
+    /// needs the public key without being allowed to trigger a KMS round trip of its own
+    /// (it is an unauthenticated RPC; an outside caller must not be able to drive KMS
+    /// traffic).
+    async fn tls_identity(&self, app_id: &str) -> Result<Arc<tls_cert::TlsIdentity>, Status> {
+        if let Some(id) = self.tls_identities.lock().await.get(app_id) {
+            return Ok(id.clone());
+        }
+
+        let secret = self
+            .kms_derive(app_id, tls_cert::KMS_MATERIAL)
+            .await
+            .map_err(|e| {
+                Status::failed_precondition(format!(
+                    "cannot derive the TLS key for {}: {}",
+                    app_id, e
+                ))
+            })?;
+        // Taking a derived secret is a measured event wherever it happens, so a key
+        // pulled for TLS shows up in the runtime log exactly like one pulled by the app.
+        self.measure_secret_resource(app_id, tls_cert::KMS_MATERIAL, true)
+            .await;
+
+        let ca_url = self.config.server.ca_url.clone();
+        let id = Arc::new(
+            tls_cert::build(app_id, &secret, ca_url.as_deref())
+                .await
+                .map_err(|e| Status::internal(format!("{}", e)))?,
+        );
+        self.tls_identities
+            .lock()
+            .await
+            .insert(app_id.to_string(), id.clone());
+        Ok(id)
+    }
+
+    /// The TLS public key hash to put in `report_data`, if one has been derived.
+    ///
+    /// Absent means no TLS key exists yet for this app — not that one is being withheld.
+    /// The two are distinguishable in practice: an endpoint serving TLS whose evidence
+    /// names no key fails the comparison a verifier makes.
+    async fn tls_public_key_for_evidence(&self, app_id: &str) -> Option<String> {
+        self.tls_identities
+            .lock()
+            .await
+            .get(app_id)
+            .map(|id| format!("0x{}", id.public_key_sha256))
+    }
+
     /// Record that a KMS-derived secret left this node, into RTMR3.
     ///
     /// Without this, a derived key can be pulled by any container on the box and nothing
@@ -248,6 +358,7 @@ impl TappServiceImpl {
         info!("All TAPP service components initialized successfully");
 
         Ok(Self {
+            tls_identities: Arc::new(Mutex::new(HashMap::new())),
             boot_service,
             app_key_service,
             kms_client,
@@ -349,9 +460,13 @@ impl TappService for TappServiceImpl {
             .app_key_service
             .get_app_key(&req.app_id, "ethereum", false)
             .await?;
+        // Reported only if a TLS key has already been derived. Deriving one here would let
+        // an unauthenticated caller drive KMS traffic, and would also mint a key for an
+        // app that never asked for one.
+        let tls_public_key = self.tls_public_key_for_evidence(&req.app_id).await;
         let evidence = self
             .boot_service
-            .get_evidence(req, &key_pair.eth_address)
+            .get_evidence(req, &key_pair.eth_address, tls_public_key)
             .await?;
         Ok(Response::new(evidence))
     }
@@ -543,6 +658,60 @@ impl TappService for TappServiceImpl {
             public_key: key_pair.public_key,
             x25519_public_key: key_pair.x25519_public_key.unwrap_or_default(),
             key_source: "in-memory".to_string(),
+        }))
+    }
+
+    async fn get_app_tls_cert(
+        &self,
+        request: Request<GetAppTlsCertRequest>,
+    ) -> Result<Response<GetAppTlsCertResponse>, Status> {
+        info!("Calling GetAppTlsCert");
+
+        // SECURITY: this hands over a private key, so it is restricted exactly like
+        // GetAppSecretKey — same host only. The app container is inside this CVM, so the
+        // key does not cross the enclave boundary.
+        let remote_addr = request.remote_addr();
+        let allowed = remote_addr
+            .map(|a| Self::is_allowed_local_access(a.ip()))
+            .unwrap_or(true); // Unix socket
+        if !allowed {
+            tracing::error!(
+                remote_addr = ?remote_addr,
+                event = "TLS_CERT_ACCESS_DENIED",
+                "Rejected GetAppTlsCert from a non-local address"
+            );
+            return Err(Status::permission_denied(
+                "GetAppTlsCert can only be called from localhost or same-host Docker containers",
+            ));
+        }
+
+        let req = request.into_inner();
+        if req.app_id.is_empty() {
+            return Err(Status::invalid_argument("app_id cannot be empty"));
+        }
+
+        let id = self.tls_identity(&req.app_id).await?;
+
+        tracing::warn!(
+            app_id = %req.app_id,
+            issuer = id.issuer,
+            public_key_sha256 = %id.public_key_sha256,
+            event = "TLS_CERT_RETRIEVED",
+            "TLS key and certificate handed to a local caller"
+        );
+
+        Ok(Response::new(GetAppTlsCertResponse {
+            success: true,
+            message: format!(
+                "TLS identity for {} ({})",
+                tls_cert::dns_name(&req.app_id),
+                id.issuer
+            ),
+            key_pem: id.key_pem.clone(),
+            cert_pem: id.cert_pem.clone(),
+            issuer: id.issuer.to_string(),
+            csr_pem: id.csr_pem.clone(),
+            public_key_sha256: id.public_key_sha256.clone(),
         }))
     }
 
@@ -1750,50 +1919,7 @@ impl TappService for TappServiceImpl {
         let req = request.into_inner();
         let app_id = &req.app_id;
 
-        let kms_guard = self.kms_client.read().await;
-        let kms = kms_guard.as_ref().ok_or_else(|| {
-            Status::failed_precondition(
-                "KMS not configured — set [kbs] node_urls in config.toml or call claim-config \
-                 with --kbs-urls",
-            )
-        })?;
-
-        // Get in-memory key pair: private key for signing + decryption, pubkey for KMS encryption target
-        let private_key = self
-            .app_key_service
-            .get_private_key(app_id)
-            .await
-            .map_err(|e| Status::internal(format!("Failed to get app key: {}", e)))?;
-
-        let (_, secp256k1_pubkey_64, _) = self
-            .app_key_service
-            .get_public_key(app_id)
-            .await
-            .map_err(|e| Status::internal(format!("Failed to get app public key: {}", e)))?;
-
-        // ecies expects uncompressed secp256k1 pubkey: 0x04 || 64 bytes
-        let pubkey_uncompressed = [&[0x04u8], secp256k1_pubkey_64.as_slice()].concat();
-        let pubkey_hex = hex::encode(&pubkey_uncompressed);
-
-        // Sign KMS request: EIP-191 personal_sign over "GetSecretResource:{timestamp}"
-        // (KMS server verifies via ecrecover, so signature must be 65-byte r||s||v).
-        let timestamp = chrono::Utc::now().timestamp();
-        let message = signature_auth::build_sign_message("GetSecretResource", timestamp);
-        let signature = app_key::sign_message_eip191(&private_key, message.as_bytes())
-            .map_err(|e| Status::internal(format!("Failed to sign KMS request: {}", e)))?;
-        let signature_hex = hex::encode(&signature);
-
-        // Call KMS cluster → get ECIES-encrypted app key. `material` is opaque
-        // derivation material forwarded verbatim (empty = omitted, derives
-        // purely from the app_id namespace as before) — see issue #33.
-        let encrypted = kms
-            .get_encrypted_secret(app_id, timestamp, &pubkey_hex, &signature_hex, &req.material)
-            .await
-            .map_err(|e| Status::unavailable(format!("KMS request failed: {}", e)))?;
-
-        // Decrypt with our private key
-        let secret = ecies::decrypt(&private_key, &encrypted)
-            .map_err(|e| Status::internal(format!("Failed to decrypt KMS secret: {}", e)))?;
+        let secret = self.kms_derive(app_id, &req.material).await?;
 
         self.measure_secret_resource(app_id, &req.material, true).await;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 pub use tapp_common::app_key;
 pub use tapp_common::onchain;
 pub use tapp_common::error;
+pub use tapp_common::report_data;
 pub use tapp_common::verify;
 pub use tapp_common::proto;
 pub use tapp_common::as_proto;
@@ -66,6 +67,74 @@ pub struct TappServiceImpl {
 }
 
 impl TappServiceImpl {
+    /// Record that a KMS-derived secret left this node, into RTMR3.
+    ///
+    /// Without this, a derived key can be pulled by any container on the box and nothing
+    /// in the attestation says it happened — `get_app_secret_key` has always been measured,
+    /// but this path, which is how a key derived from the KMS namespace is obtained, was
+    /// not. It is what makes "re-acquiring a key leaves a trace" true rather than assumed.
+    ///
+    /// `material` is recorded because it names the derivation namespace, which is the part
+    /// that says *which* secret was taken. Failure to measure never fails the request: the
+    /// caller already holds the secret by this point, so refusing to answer would hide the
+    /// event rather than prevent it.
+    async fn measure_secret_resource(&self, app_id: &str, material: &str, success: bool) {
+        // Best-effort: an app fetching a secret before its measurements are known is
+        // unusual but must still be recorded, so missing app_info leaves empty hashes
+        // rather than skipping the event.
+        let info = self.boot_service.get_app_info(app_id).await.ok().flatten();
+        let m = boot::AppMeasurement {
+            app_id: app_id.to_string(),
+            operation: measurement_service::OPERATION_NAME_GET_SECRET_RESOURCE.to_string(),
+            result: String::new(),
+            error: None,
+            compose_hash: info
+                .as_ref()
+                .map(|i| i.compose_content.hash.clone())
+                .unwrap_or_default(),
+            volumes_hash: info
+                .as_ref()
+                .map(|i| i.mount_files.hash.clone())
+                .unwrap_or_default(),
+            image_hash: info
+                .as_ref()
+                .map(|i| i.compose_content.image_hash.clone())
+                .unwrap_or_default(),
+            deployer: info.as_ref().map(|i| i.owner.clone()).unwrap_or_default(),
+            timestamp: utils::current_timestamp(),
+        };
+        let m = if success {
+            m.with_success()
+        } else {
+            m.with_failure("KMS request or decryption failed".to_string())
+        };
+
+        // `material` has no field on AppMeasurement, so it is added to the serialised
+        // object rather than changing a struct every other measured operation shares.
+        let mut payload = match serde_json::to_value(&m) {
+            Ok(serde_json::Value::Object(o)) => o,
+            _ => {
+                tracing::error!("failed to serialise get_secret_resource measurement");
+                return;
+            }
+        };
+        payload.insert(
+            "material".to_string(),
+            serde_json::Value::String(material.to_string()),
+        );
+
+        if let Err(e) = self
+            .measurement_service
+            .extend_measurement(
+                measurement_service::OPERATION_NAME_GET_SECRET_RESOURCE,
+                &serde_json::Value::Object(payload).to_string(),
+            )
+            .await
+        {
+            tracing::error!("Failed to extend measurement for get_secret_resource: {}", e);
+        }
+    }
+
     /// Check if an IP address is allowed for local access
     /// Allows:
     /// - Localhost (127.0.0.1, ::1)
@@ -449,13 +518,15 @@ impl TappService for TappServiceImpl {
         debug!("Request: {:?}", request);
         let req = request.into_inner();
 
-        // Default to "ethereum" if key_type is not specified
-        // TODO: Remove
-        // let key_type = if req.key_type.is_empty() {
-        //     "ethereum"
-        // } else {
-        //     &req.key_type
-        // };
+        // Empty means "ethereum", the only kind that exists. Anything else is refused
+        // rather than quietly answered with ethereum material: the field was accepted and
+        // discarded for a long time, so a caller asking for "rsa" got an ethereum key and
+        // no indication that its request had not been honoured.
+        let key_type = if req.key_type.is_empty() {
+            "ethereum"
+        } else {
+            &req.key_type
+        };
 
         // Create-if-missing (same as GetEvidence): allows fetching the signer
         // address BEFORE the app starts, e.g. for on-chain pre-registration.
@@ -463,7 +534,7 @@ impl TappService for TappServiceImpl {
         // when it actually starts.
         let key_pair = self
             .app_key_service
-            .get_app_key(&req.app_id, "ethereum", req.x25519)
+            .get_app_key(&req.app_id, key_type, req.x25519)
             .await?;
         Ok(Response::new(GetAppKeyResponse {
             success: true,
@@ -1723,6 +1794,8 @@ impl TappService for TappServiceImpl {
         // Decrypt with our private key
         let secret = ecies::decrypt(&private_key, &encrypted)
             .map_err(|e| Status::internal(format!("Failed to decrypt KMS secret: {}", e)))?;
+
+        self.measure_secret_resource(app_id, &req.material, true).await;
 
         info!(app_id = %app_id, "GetSecretResource succeeded");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,33 +136,58 @@ impl TappServiceImpl {
 
     /// The app's TLS identity, derived on first use and kept for the process lifetime.
     ///
-    /// Cached because the certificate is asked for on every app start and on every
-    /// renewal check, while the underlying key never changes — and because `GetEvidence`
-    /// needs the public key without being allowed to trigger a KMS round trip of its own
-    /// (it is an unauthenticated RPC; an outside caller must not be able to drive KMS
+    /// Cached because the certificate is asked for on every app start and every renewal
+    /// check while the key behind it does not change within a boot — and because
+    /// `GetEvidence` needs the public key without being allowed to trigger a KMS round trip
+    /// of its own (it is unauthenticated; an outside caller must not be able to drive KMS
     /// traffic).
+    ///
+    /// Where the key comes from is a real choice, not a fallback — see
+    /// [`config::TlsKeySource`].
     async fn tls_identity(&self, app_id: &str) -> Result<Arc<tls_cert::TlsIdentity>, Status> {
         if let Some(id) = self.tls_identities.lock().await.get(app_id) {
             return Ok(id.clone());
         }
 
-        let secret = self
-            .kms_derive(app_id, tls_cert::KMS_MATERIAL)
-            .await
-            .map_err(|e| {
-                Status::failed_precondition(format!(
-                    "cannot derive the TLS key for {}: {}",
-                    app_id, e
-                ))
-            })?;
-        // Taking a derived secret is a measured event wherever it happens, so a key
-        // pulled for TLS shows up in the runtime log exactly like one pulled by the app.
-        self.measure_secret_resource(app_id, tls_cert::KMS_MATERIAL, true)
-            .await;
+        let source = self.config.server.tls_key_source;
+        let secret = match source {
+            config::TlsKeySource::Local => {
+                // Create-if-missing, then derive from the signer. `get_private_key` only
+                // reads the cache, so an app asking for a certificate as its first action
+                // would otherwise find nothing.
+                self.app_key_service
+                    .get_app_key(app_id, "ethereum", false)
+                    .await
+                    .map_err(|e| Status::internal(format!("Failed to create app key: {}", e)))?;
+                let signer_key = self
+                    .app_key_service
+                    .get_private_key(app_id)
+                    .await
+                    .map_err(|e| Status::internal(format!("Failed to get app key: {}", e)))?;
+                tls_cert::derive_from_signer(&signer_key)
+            }
+            config::TlsKeySource::Kms => {
+                let secret = self
+                    .kms_derive(app_id, tls_cert::KMS_MATERIAL)
+                    .await
+                    .map_err(|e| {
+                        Status::failed_precondition(format!(
+                            "cannot derive the TLS key for {}: {}",
+                            app_id, e
+                        ))
+                    })?;
+                // Taking a derived secret is a measured event wherever it happens, so a key
+                // pulled for TLS shows up in the runtime log exactly like one pulled by the
+                // app itself. The local path has nothing to measure — no secret moved.
+                self.measure_secret_resource(app_id, tls_cert::KMS_MATERIAL, true)
+                    .await;
+                secret
+            }
+        };
 
         let ca_url = self.config.server.ca_url.clone();
         let id = Arc::new(
-            tls_cert::build(app_id, &secret, ca_url.as_deref())
+            tls_cert::build(app_id, &secret, source.as_str(), ca_url.as_deref())
                 .await
                 .map_err(|e| Status::internal(format!("{}", e)))?,
         );
@@ -712,8 +737,9 @@ impl TappService for TappServiceImpl {
         Ok(Response::new(GetAppTlsCertResponse {
             success: true,
             message: format!(
-                "TLS identity for {} ({})",
+                "TLS identity for {} ({} key, {} certificate)",
                 tls_cert::dns_name(&req.app_id),
+                id.key_source,
                 id.issuer
             ),
             key_pem: id.key_pem.clone(),
@@ -721,6 +747,7 @@ impl TappService for TappServiceImpl {
             issuer: id.issuer.to_string(),
             csr_pem: id.csr_pem.clone(),
             public_key_sha256: id.public_key_sha256.clone(),
+            key_source: id.key_source.to_string(),
         }))
     }
 

--- a/src/measurement_service.rs
+++ b/src/measurement_service.rs
@@ -18,6 +18,7 @@ pub const OPERATION_NAME_DOCKER_LOGOUT: &str = "docker_logout";
 pub const OPERATION_NAME_STOP_SERVICE: &str = "stop_service";
 pub const OPERATION_NAME_START_SERVICE: &str = "start_service";
 pub const OPERATION_NAME_CLAIM_CONFIG: &str = "claim_config";
+pub const OPERATION_NAME_GET_SECRET_RESOURCE: &str = "get_secret_resource";
 
 pub struct MeasurementService {
     aa: Arc<Mutex<AttestationAgent>>,

--- a/src/tls_cert.rs
+++ b/src/tls_cert.rs
@@ -1,0 +1,208 @@
+//! The app's TLS identity: a P-256 key derived from KMS, plus a certificate for it.
+//!
+//! Two properties are load-bearing and neither is obvious from the code alone:
+//!
+//! **The key is derived, not generated.** KMS derives it from `(app_id, "tls")`, so it is
+//! the same key after a restart and the same key on every node serving the app. That is
+//! what lets a certificate outlive a reboot, lets a client pin the public key, and makes
+//! an unexpected key in a Certificate Transparency log meaningful rather than noise. A
+//! freshly random key per boot would give up all three.
+//!
+//! **Self-signed is not a lesser certificate here.** What a verifier checks is the public
+//! key against the one the quote committed to; who signed the certificate is irrelevant to
+//! that. The issuer matters only for clients that will not do the check — browsers and
+//! anything else driving off a system trust store.
+
+use crate::error::{DockerError, TappResult};
+use p256::pkcs8::EncodePrivateKey;
+use sha2::{Digest, Sha256};
+
+/// Derivation namespace. Deliberately not the app's signer material: a key used for TLS
+/// handshakes should not also be the identity that signs chain transactions and decrypts
+/// KMS payloads.
+pub const KMS_MATERIAL: &str = "tls";
+
+/// Names are ours to hand out, so no domain-control validation is involved. A private CA
+/// that would sign arbitrary names is an interception tool against everyone holding its
+/// root, so issuance stays inside a namespace we own. Custom domains go to a public CA.
+const NAME_SUFFIX: &str = "tapp.0g.ai";
+
+/// When a self-signed certificate stops claiming validity. Deliberately far out: nothing
+/// checks it, so an expiry would only break clients one day without having protected
+/// anyone in the meantime. A CA-issued certificate gets whatever lifetime the CA decides,
+/// and that one does mean something.
+const SELF_SIGNED_NOT_AFTER: (i32, u8, u8) = (2035, 1, 1);
+
+pub struct TlsIdentity {
+    pub key_pem: String,
+    pub cert_pem: String,
+    pub csr_pem: String,
+    pub issuer: &'static str,
+    /// sha256 of the SubjectPublicKeyInfo, hex. What `report_data` commits to.
+    pub public_key_sha256: String,
+}
+
+fn fail(reason: impl Into<String>) -> crate::error::TappError {
+    DockerError::ContainerOperationFailed {
+        operation: "app_tls_cert".to_string(),
+        reason: reason.into(),
+    }
+    .into()
+}
+
+/// The name this app's certificate is issued for.
+pub fn dns_name(app_id: &str) -> String {
+    format!("{}.{}", app_id, NAME_SUFFIX)
+}
+
+/// sha256 of a DER-encoded SubjectPublicKeyInfo, hex.
+///
+/// The public key rather than the whole certificate: the key is what the TEE holds and
+/// what survives reissuance, and it is also the unit every certificate-pinning
+/// implementation uses.
+pub fn public_key_sha256_hex(spki_der: &[u8]) -> String {
+    hex::encode(Sha256::digest(spki_der))
+}
+
+/// Turn KMS-derived bytes into a certificate, asking `ca_url` to sign when one is set.
+///
+/// Without a CA the certificate is self-signed and the signing request is returned
+/// alongside, so the deployer can obtain a publicly-trusted certificate for the same key
+/// later without coming back for the key.
+pub async fn build(app_id: &str, secret: &[u8], ca_url: Option<&str>) -> TappResult<TlsIdentity> {
+    // A derived secret is uniform bytes; P-256 wants a scalar in range, which from_slice
+    // enforces. Rejecting is correct rather than reducing: a secret that does not map to a
+    // valid key means the derivation changed shape, and quietly mangling it would produce
+    // a key nobody can reproduce.
+    let secret_key = p256::SecretKey::from_slice(secret)
+        .map_err(|e| fail(format!("derived secret is not a valid P-256 key: {}", e)))?;
+    let pkcs8 = secret_key
+        .to_pkcs8_der()
+        .map_err(|e| fail(format!("encode private key: {}", e)))?;
+
+    let key_pair = rcgen::KeyPair::from_pkcs8_der_and_sign_algo(
+        &rustls_pki_types::PrivatePkcs8KeyDer::from(pkcs8.as_bytes()),
+        &rcgen::PKCS_ECDSA_P256_SHA256,
+    )
+    .map_err(|e| fail(format!("load key pair: {}", e)))?;
+    let public_key_sha256 = public_key_sha256_hex(&key_pair.public_key_der());
+
+    let name = dns_name(app_id);
+    let mut params = rcgen::CertificateParams::new(vec![name.clone()])
+        .map_err(|e| fail(format!("certificate params: {}", e)))?;
+    params
+        .distinguished_name
+        .push(rcgen::DnType::CommonName, name.clone());
+    // Usable in both directions. An app calling another app presents this same
+    // certificate as a client certificate, and a strict peer refuses one that only
+    // claims server authentication.
+    params.use_authority_key_identifier_extension = false;
+    params.extended_key_usages = vec![
+        rcgen::ExtendedKeyUsagePurpose::ServerAuth,
+        rcgen::ExtendedKeyUsagePurpose::ClientAuth,
+    ];
+
+    let csr_pem = params
+        .serialize_request(&key_pair)
+        .map_err(|e| fail(format!("build signing request: {}", e)))?
+        .pem()
+        .map_err(|e| fail(format!("encode signing request: {}", e)))?;
+
+    let (cert_pem, issuer) = match ca_url {
+        Some(url) => (sign_with_ca(url, &csr_pem).await?, "ca"),
+        None => {
+            let mut p = params;
+            let (y, m, d) = SELF_SIGNED_NOT_AFTER;
+            p.not_after = rcgen::date_time_ymd(y, m, d);
+            (
+                p.self_signed(&key_pair)
+                    .map_err(|e| fail(format!("self-sign: {}", e)))?
+                    .pem(),
+                "self-signed",
+            )
+        }
+    };
+
+    Ok(TlsIdentity {
+        key_pem: key_pair.serialize_pem(),
+        cert_pem,
+        csr_pem,
+        issuer,
+        public_key_sha256,
+    })
+}
+
+/// Hand the signing request to the CA. Nothing secret travels: a signing request carries
+/// the public key and a proof of possession, never the private key, and a certificate is
+/// public by definition — so this needs no confidential channel, only a truthful answer,
+/// which the caller gets by checking the result chains to a root it already trusts.
+async fn sign_with_ca(ca_url: &str, csr_pem: &str) -> TappResult<String> {
+    let resp = reqwest::Client::new()
+        .post(format!("{}/sign", ca_url.trim_end_matches('/')))
+        .header("content-type", "application/x-pem-file")
+        .body(csr_pem.to_string())
+        .send()
+        .await
+        .map_err(|e| fail(format!("CA {} unreachable: {}", ca_url, e)))?;
+    let status = resp.status();
+    let body = resp.text().await.unwrap_or_default();
+    if !status.is_success() {
+        return Err(fail(format!("CA {} returned {}: {}", ca_url, status, body)));
+    }
+    if !body.contains("BEGIN CERTIFICATE") {
+        return Err(fail(format!("CA {} did not return a certificate", ca_url)));
+    }
+    Ok(body)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A fixed, valid P-256 scalar — stands in for whatever KMS derives.
+    const SECRET: [u8; 32] = [
+        0x4c, 0x0b, 0x1f, 0x6d, 0x2a, 0x91, 0x33, 0x7e, 0x58, 0xc4, 0x0d, 0xa2, 0x66, 0x19,
+        0xfb, 0x87, 0x35, 0x92, 0xee, 0x41, 0x7a, 0x0c, 0xb3, 0x5d, 0x28, 0x6f, 0x94, 0x11,
+        0xd7, 0x03, 0x8a, 0x56,
+    ];
+
+    #[tokio::test]
+    async fn the_same_derived_secret_always_yields_the_same_public_key() {
+        // This is the property the whole design leans on: restarts and other nodes of the
+        // same app must present the same key, or pinning and CT monitoring are worthless.
+        let a = build("demo", &SECRET, None).await.unwrap();
+        let b = build("demo", &SECRET, None).await.unwrap();
+        assert_eq!(a.public_key_sha256, b.public_key_sha256);
+        assert_eq!(a.key_pem, b.key_pem);
+    }
+
+    #[tokio::test]
+    async fn a_different_app_gets_a_different_key_only_because_kms_derives_differently() {
+        // Same secret, different app: identical keys. The separation comes from the
+        // derivation namespace, never from anything this module does.
+        let a = build("one", &SECRET, None).await.unwrap();
+        let b = build("two", &SECRET, None).await.unwrap();
+        assert_eq!(a.public_key_sha256, b.public_key_sha256);
+        assert_ne!(a.cert_pem, b.cert_pem, "but the names differ");
+    }
+
+    #[tokio::test]
+    async fn without_a_ca_the_certificate_is_self_signed_and_the_request_still_comes_back() {
+        let id = build("demo", &SECRET, None).await.unwrap();
+        assert_eq!(id.issuer, "self-signed");
+        assert!(id.cert_pem.contains("BEGIN CERTIFICATE"));
+        assert!(id.csr_pem.contains("BEGIN CERTIFICATE REQUEST"));
+        assert!(id.key_pem.contains("BEGIN PRIVATE KEY"));
+    }
+
+    #[tokio::test]
+    async fn the_name_is_derived_from_the_app_id_not_supplied_by_the_caller() {
+        assert_eq!(dns_name("0g-sandbox-provider"), "0g-sandbox-provider.tapp.0g.ai");
+    }
+
+    #[tokio::test]
+    async fn a_secret_that_is_not_a_valid_key_is_refused_rather_than_reduced() {
+        assert!(build("demo", &[0u8; 32], None).await.is_err(), "zero is not a scalar");
+        assert!(build("demo", &[0u8; 16], None).await.is_err(), "wrong length");
+    }
+}

--- a/src/tls_cert.rs
+++ b/src/tls_cert.rs
@@ -1,17 +1,22 @@
-//! The app's TLS identity: a P-256 key derived from KMS, plus a certificate for it.
+//! The app's TLS identity: a P-256 key plus a certificate for it.
 //!
-//! Two properties are load-bearing and neither is obvious from the code alone:
+//! Three things here are load-bearing and none is obvious from the code alone.
 //!
-//! **The key is derived, not generated.** KMS derives it from `(app_id, "tls")`, so it is
-//! the same key after a restart and the same key on every node serving the app. That is
-//! what lets a certificate outlive a reboot, lets a client pin the public key, and makes
-//! an unexpected key in a Certificate Transparency log meaningful rather than noise. A
-//! freshly random key per boot would give up all three.
+//! **The key is always derived, never randomly generated** — but from one of two places,
+//! and the choice changes what a verifier learns. See [`crate::config::TlsKeySource`]: from
+//! the app's own signer, the key never leaves this CVM and the statement is "you are talking
+//! to *this* TEE"; from KMS, the key is stable across restarts and shared by every node of
+//! the app, which is what pinning and transparency monitoring need, and the statement
+//! weakens to "some TEE of this app". Neither is the safe default for all cases.
 //!
 //! **Self-signed is not a lesser certificate here.** What a verifier checks is the public
-//! key against the one the quote committed to; who signed the certificate is irrelevant to
+//! key against the one the quote committed to; who signed the certificate has no part in
 //! that. The issuer matters only for clients that will not do the check — browsers and
 //! anything else driving off a system trust store.
+//!
+//! **Randomness would be worse than either.** A fresh key per process would still be
+//! attestable, but it could not be reproduced by anything, so a key that appeared in a log
+//! or a pin could never be checked against an expectation.
 
 use crate::error::{DockerError, TappResult};
 use p256::pkcs8::EncodePrivateKey;
@@ -20,7 +25,12 @@ use sha2::{Digest, Sha256};
 /// Derivation namespace. Deliberately not the app's signer material: a key used for TLS
 /// handshakes should not also be the identity that signs chain transactions and decrypts
 /// KMS payloads.
-pub const KMS_MATERIAL: &str = "tls";
+///
+/// **Hex, because KMS decodes it** (`proto/tapp_service.proto`: "hex-encoded derivation
+/// material"). Passing the ASCII `"tls"` gets a 500 from the cluster, which is not obvious
+/// from anything on this side — hence the constant rather than a literal at the call site.
+/// This is `hex("tls")`, kept legible so it can still be recognised in a log.
+pub const KMS_MATERIAL: &str = "746c73";
 
 /// Names are ours to hand out, so no domain-control validation is involved. A private CA
 /// that would sign arbitrary names is an interception tool against everyone holding its
@@ -38,6 +48,9 @@ pub struct TlsIdentity {
     pub cert_pem: String,
     pub csr_pem: String,
     pub issuer: &'static str,
+    /// "local" or "kms" — which derivation produced this key. Reported because a client
+    /// deciding whether to pin the public key needs to know if it survives a restart.
+    pub key_source: &'static str,
     /// sha256 of the SubjectPublicKeyInfo, hex. What `report_data` commits to.
     pub public_key_sha256: String,
 }
@@ -64,12 +77,31 @@ pub fn public_key_sha256_hex(spki_der: &[u8]) -> String {
     hex::encode(Sha256::digest(spki_der))
 }
 
-/// Turn KMS-derived bytes into a certificate, asking `ca_url` to sign when one is set.
+/// The TLS key belonging to an app signer, for the local (no-KMS) source.
+///
+/// Hashed with a domain separator rather than used directly: the signer is a secp256k1
+/// scalar and this must be a P-256 one, ranges differ, and one key doing two jobs on two
+/// curves is how cross-protocol mistakes start. Hashing also makes the derivation one-way,
+/// so possession of the TLS key says nothing about the signer — which matters, because the
+/// signer is the identity that signs chain transactions and decrypts KMS payloads.
+pub fn derive_from_signer(signer_private_key: &[u8]) -> Vec<u8> {
+    let mut h = Sha256::new();
+    h.update(b"tapp-tls-v1");
+    h.update(signer_private_key);
+    h.finalize().to_vec()
+}
+
+/// Turn derived bytes into a certificate, asking `ca_url` to sign when one is set.
 ///
 /// Without a CA the certificate is self-signed and the signing request is returned
 /// alongside, so the deployer can obtain a publicly-trusted certificate for the same key
 /// later without coming back for the key.
-pub async fn build(app_id: &str, secret: &[u8], ca_url: Option<&str>) -> TappResult<TlsIdentity> {
+pub async fn build(
+    app_id: &str,
+    secret: &[u8],
+    key_source: &'static str,
+    ca_url: Option<&str>,
+) -> TappResult<TlsIdentity> {
     // A derived secret is uniform bytes; P-256 wants a scalar in range, which from_slice
     // enforces. Rejecting is correct rather than reducing: a secret that does not map to a
     // valid key means the derivation changed shape, and quietly mangling it would produce
@@ -128,6 +160,7 @@ pub async fn build(app_id: &str, secret: &[u8], ca_url: Option<&str>) -> TappRes
         cert_pem,
         csr_pem,
         issuer,
+        key_source,
         public_key_sha256,
     })
 }
@@ -170,8 +203,8 @@ mod tests {
     async fn the_same_derived_secret_always_yields_the_same_public_key() {
         // This is the property the whole design leans on: restarts and other nodes of the
         // same app must present the same key, or pinning and CT monitoring are worthless.
-        let a = build("demo", &SECRET, None).await.unwrap();
-        let b = build("demo", &SECRET, None).await.unwrap();
+        let a = build("demo", &SECRET, "local", None).await.unwrap();
+        let b = build("demo", &SECRET, "local", None).await.unwrap();
         assert_eq!(a.public_key_sha256, b.public_key_sha256);
         assert_eq!(a.key_pem, b.key_pem);
     }
@@ -180,15 +213,15 @@ mod tests {
     async fn a_different_app_gets_a_different_key_only_because_kms_derives_differently() {
         // Same secret, different app: identical keys. The separation comes from the
         // derivation namespace, never from anything this module does.
-        let a = build("one", &SECRET, None).await.unwrap();
-        let b = build("two", &SECRET, None).await.unwrap();
+        let a = build("one", &SECRET, "local", None).await.unwrap();
+        let b = build("two", &SECRET, "local", None).await.unwrap();
         assert_eq!(a.public_key_sha256, b.public_key_sha256);
         assert_ne!(a.cert_pem, b.cert_pem, "but the names differ");
     }
 
     #[tokio::test]
     async fn without_a_ca_the_certificate_is_self_signed_and_the_request_still_comes_back() {
-        let id = build("demo", &SECRET, None).await.unwrap();
+        let id = build("demo", &SECRET, "local", None).await.unwrap();
         assert_eq!(id.issuer, "self-signed");
         assert!(id.cert_pem.contains("BEGIN CERTIFICATE"));
         assert!(id.csr_pem.contains("BEGIN CERTIFICATE REQUEST"));
@@ -202,7 +235,61 @@ mod tests {
 
     #[tokio::test]
     async fn a_secret_that_is_not_a_valid_key_is_refused_rather_than_reduced() {
-        assert!(build("demo", &[0u8; 32], None).await.is_err(), "zero is not a scalar");
-        assert!(build("demo", &[0u8; 16], None).await.is_err(), "wrong length");
+        assert!(build("demo", &[0u8; 32], "local", None).await.is_err(), "zero is not a scalar");
+        assert!(build("demo", &[0u8; 16], "local", None).await.is_err(), "wrong length");
+    }
+}
+
+#[cfg(test)]
+mod material {
+    /// KMS decodes the derivation material as hex, so a readable ASCII namespace silently
+    /// becomes a 500 from the cluster. Cheap to assert, and the failure it prevents costs
+    /// a real deployment to discover.
+    #[test]
+    fn the_derivation_material_is_valid_hex() {
+        assert!(
+            hex::decode(super::KMS_MATERIAL).is_ok(),
+            "KMS_MATERIAL must be hex; KMS rejects anything else"
+        );
+    }
+}
+
+#[cfg(test)]
+mod local_derivation {
+    use super::*;
+
+    const SIGNER: [u8; 32] = [0x7f; 32];
+
+    #[test]
+    fn the_tls_key_is_not_the_signer_key() {
+        // Reusing the signer scalar directly would put one key on two curves doing two
+        // jobs — and would mean holding the TLS key implies holding the chain identity.
+        assert_ne!(derive_from_signer(&SIGNER), SIGNER.to_vec());
+    }
+
+    #[test]
+    fn the_same_signer_always_gives_the_same_tls_key() {
+        // Within one boot the signer does not change, so neither may this: an app asking
+        // twice must get the same certificate rather than silently rotating.
+        assert_eq!(derive_from_signer(&SIGNER), derive_from_signer(&SIGNER));
+    }
+
+    #[test]
+    fn a_different_signer_gives_a_different_tls_key() {
+        // The point of the local source: the key is bound to this instance, and a restart
+        // re-derives the signer, so the TLS key must move with it.
+        assert_ne!(derive_from_signer(&SIGNER), derive_from_signer(&[0x11; 32]));
+    }
+
+    #[tokio::test]
+    async fn a_locally_derived_secret_is_a_usable_p256_key() {
+        // sha256 output is uniform over 32 bytes, so it can in principle fall outside the
+        // P-256 order. Checking a real derivation reaches a certificate keeps that from
+        // being a theory nobody tested.
+        let id = build("demo", &derive_from_signer(&SIGNER), "local", None)
+            .await
+            .unwrap();
+        assert_eq!(id.key_source, "local");
+        assert!(id.cert_pem.contains("BEGIN CERTIFICATE"));
     }
 }

--- a/tapp-cli/Cargo.toml
+++ b/tapp-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tapp-cli"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 description = "Standalone CLI for TAPP gRPC server and on-chain operations"
 license.workspace = true

--- a/tapp-cli/src/main.rs
+++ b/tapp-cli/src/main.rs
@@ -4,7 +4,8 @@ use tapp_common::proto::{
     tapp_service_client::TappServiceClient, AddToWhitelistRequest, ClaimConfigRequest,
     DockerLoginRequest,
     DockerLogoutRequest, GetAppContainerStatusRequest, GetAppInfoRequest, GetAppKeyRequest,
-    GetAppLogsRequest, GetAppSecretKeyRequest, GetEvidenceRequest, GetSecretResourceRequest,
+    GetAppLogsRequest, GetAppSecretKeyRequest, GetAppTlsCertRequest, GetEvidenceRequest,
+    GetSecretResourceRequest,
     GetServiceLogsRequest, GetServiceStatusRequest, GetTappInfoRequest, GetTaskStatusRequest,
     ListAppsRequest, ListWhitelistRequest, MountFile, PruneImagesRequest, RemoveFromWhitelistRequest,
     StartAppRequest, StartServiceRequest, StopAppRequest, StopServiceRequest, WithdrawBalanceRequest,
@@ -217,6 +218,21 @@ enum Commands {
         /// Use X25519 key pair
         #[arg(long)]
         x25519: bool,
+    },
+
+    /// Get the app's TLS key and certificate (local access only)
+    GetAppTlsCert {
+        /// Application ID
+        #[arg(short, long)]
+        app_id: String,
+
+        /// Write the private key here instead of printing it
+        #[arg(long)]
+        out_key: Option<String>,
+
+        /// Write the certificate here instead of printing it
+        #[arg(long)]
+        out_cert: Option<String>,
     },
 
     /// Get application secret key (local access only)
@@ -646,6 +662,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         Commands::GetAppKey { app_id, x25519 } => {
             get_app_key(&cli.server, app_id, x25519).await?;
+        }
+        Commands::GetAppTlsCert {
+            app_id,
+            out_key,
+            out_cert,
+        } => {
+            get_app_tls_cert(&cli.server, app_id, out_key, out_cert).await?;
         }
         Commands::GetAppSecretKey {
             app_id,
@@ -1661,6 +1684,68 @@ async fn get_app_key(
             "  X25519 Public Key: 0x{}",
             hex::encode(&result.x25519_public_key)
         );
+    }
+
+    Ok(())
+}
+
+/// Fetch the app's TLS key and certificate.
+///
+/// Writing to files is the normal use — an app's entrypoint calls this and points its
+/// server at the two paths. Printing exists for looking at what a node holds; the key is
+/// written with owner-only permissions so a shell redirect cannot quietly leave it
+/// world-readable.
+async fn get_app_tls_cert(
+    server: &str,
+    app_id: String,
+    out_key: Option<String>,
+    out_cert: Option<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut client = create_client(server).await?;
+
+    let response = client
+        .get_app_tls_cert(Request::new(GetAppTlsCertRequest {
+            app_id: app_id.clone(),
+        }))
+        .await?;
+    let result = response.into_inner();
+
+    if !result.success {
+        eprintln!("✗ {}", result.message);
+        std::process::exit(1);
+    }
+
+    println!("✓ {}", result.message);
+    println!("  Public key sha256: {}", result.public_key_sha256);
+    println!("  Issuer           : {}", result.issuer);
+    if result.issuer == "self-signed" {
+        println!(
+            "  A verifier checks the public key against the attestation, so the issuer does not"
+        );
+        println!(
+            "  matter to it. Clients that only check a trust store (browsers) will refuse this."
+        );
+    }
+
+    match out_cert {
+        Some(path) => {
+            std::fs::write(&path, &result.cert_pem)?;
+            println!("  Certificate → {}", path);
+        }
+        None => println!("\n{}", result.cert_pem),
+    }
+
+    match out_key {
+        Some(path) => {
+            std::fs::write(&path, &result.key_pem)?;
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))?;
+            }
+            println!("  Private key → {} (0600)", path);
+        }
+        None => println!("{}", result.key_pem),
     }
 
     Ok(())

--- a/tapp-cli/src/main.rs
+++ b/tapp-cli/src/main.rs
@@ -308,6 +308,17 @@ enum Commands {
         /// e.g. "http://kms-1:9091,http://kms-2:9091"
         #[arg(long)]
         kbs_urls: Option<String>,
+
+        /// Where app TLS keys come from: "local" (default) or "kms".
+        ///
+        /// local  — derived from the app signer, never leaves this CVM, so an attested
+        ///          key proves you reached *this* instance. Changes on every restart,
+        ///          so it cannot be pinned.
+        /// kms    — stable across restarts and shared by every node of the app, which
+        ///          pinning and certificate renewal need. Requires the app registered
+        ///          on chain and the cluster reachable.
+        #[arg(long)]
+        tls_key_source: Option<String>,
     },
 
     AddToWhitelist {
@@ -699,6 +710,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             chain_rpc_url,
             chain_contract,
             kbs_urls,
+            tls_key_source,
         } => {
             let private_key = require_private_key(&cli.private_key)?;
             let kbs_node_urls: Vec<String> = kbs_urls
@@ -714,6 +726,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 chain_rpc_url.unwrap_or_default(),
                 chain_contract.unwrap_or_default(),
                 kbs_node_urls,
+                tls_key_source,
             )
             .await?;
         }
@@ -1960,6 +1973,7 @@ async fn claim_config(
     chain_rpc_url: String,
     chain_contract_address: String,
     kbs_node_urls: Vec<String>,
+    tls_key_source: Option<String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     use ethers::signers::Signer;
 
@@ -1975,6 +1989,7 @@ async fn claim_config(
         chain_rpc_url: chain_rpc_url.clone(),
         chain_contract_address: chain_contract_address.clone(),
         kbs_node_urls: kbs_node_urls.clone(),
+        tls_key_source: tls_key_source.clone().unwrap_or_default(),
     });
     add_signature_metadata(&mut request, &private_key, "ClaimConfig")?;
 
@@ -2020,6 +2035,10 @@ async fn claim_config(
         .and_then(|c| c.server.as_ref())
         .map(|s| s.owner_address.clone())
         .unwrap_or_default();
+
+    if let Some(src) = tls_key_source.as_deref().filter(|s| !s.is_empty()) {
+        println!("  TLS keys: {}", src);
+    }
 
     if live_owner == my_address {
         println!("  Verified: server now reports this address as owner");

--- a/tapp-cli/src/main.rs
+++ b/tapp-cli/src/main.rs
@@ -1220,6 +1220,42 @@ async fn ensure_registered_onchain(
         // Store a per-node override only when it differs from the app-level default
         let (compose_override, volumes_override) =
             node_override_hashes(&rpc_url, &contract, app_id, compose_hash, volumes_hash).await?;
+
+        // A signer that is not in the node list is usually not a new machine — it is this
+        // machine after a restart, which re-derives the signer. Adding would leave the dead
+        // address registered, holding its stake, and being fetched for evidence it can no
+        // longer produce; every restart would add another. Replacing keeps the slot and moves
+        // the stake, which is what the KMS runbook already tells operators to do by hand.
+        //
+        // Only when the chain shows exactly one other node, though: with several, which one
+        // this replaces is not knowable from here, and guessing moves someone else's stake.
+        // Then adding is the safe reading, and an operator who meant to replace can say so
+        // with update-node-onchain --old-signer.
+        match node_being_replaced(&rpc_url, &contract, app_id, signer).await {
+            Ok(Some(old)) => {
+                let tx = onchain::update_node(
+                    &params,
+                    app_id,
+                    old,
+                    signer,
+                    server.to_string(),
+                    compose_override,
+                    volumes_override,
+                )
+                .await?;
+                println!("✓ Node signer replaced on-chain (stake and slot preserved)");
+                println!("  Old Signer: 0x{:x}", old);
+                println!("  New Signer: 0x{:x}", signer);
+                println!("  Tx Hash: 0x{:x}", tx);
+                return Ok(());
+            }
+            Ok(None) => {}
+            Err(e) => {
+                println!("ℹ️  {}", e);
+                println!("   Adding this node instead; use update-node-onchain --old-signer to replace one.");
+            }
+        }
+
         let tx = onchain::add_node(
             &params,
             app_id,
@@ -2664,6 +2700,50 @@ async fn remove_node_onchain(
     Ok(())
 }
 
+/// The node on chain that a drifted signer is replacing.
+///
+/// A restart re-derives the signer, so the address on chain belongs to an instance that no
+/// longer exists — and cannot be asked what it was. Only the chain still knows, which is why
+/// this reads the node list rather than the server.
+///
+/// With one node there is nothing to guess. With several, which one died is not knowable from
+/// here: they share an app and may share a teeUrl, and picking wrong moves the wrong stake.
+/// So the caller is told to say, rather than a guess being made on their behalf.
+async fn node_being_replaced(
+    rpc_url: &str,
+    contract: &str,
+    app_id: &str,
+    new_signer: ethers::types::Address,
+) -> Result<Option<ethers::types::Address>, Box<dyn std::error::Error>> {
+    let nodes = tapp_common::onchain::get_node_list(rpc_url, contract, app_id).await?;
+    pick_replaced_node(&nodes, new_signer, app_id).map_err(Into::into)
+}
+
+/// The rule, kept apart from fetching so it can be tested: of the nodes on chain, which one
+/// is this signer replacing?
+fn pick_replaced_node(
+    nodes: &[ethers::types::Address],
+    new_signer: ethers::types::Address,
+    app_id: &str,
+) -> Result<Option<ethers::types::Address>, String> {
+    let others: Vec<_> = nodes.iter().copied().filter(|n| *n != new_signer).collect();
+    match others.len() {
+        0 => Ok(None),
+        1 => Ok(Some(others[0])),
+        _ => Err(format!(
+            "app {} has {} other nodes on chain ({}); pass --old-signer to say which one \
+             this replaces",
+            app_id,
+            others.len(),
+            others
+                .iter()
+                .map(|a| format!("0x{:x}", a))
+                .collect::<Vec<_>>()
+                .join(", ")
+        )),
+    }
+}
+
 async fn update_node_onchain(
     server: &str,
     app_id: String,
@@ -2678,12 +2758,6 @@ async fn update_node_onchain(
     use std::str::FromStr;
     use tapp_common::onchain::OnchainParams;
 
-    let old_signer_addr = if let Some(addr) = old_signer_arg {
-        Address::from_str(addr.trim_start_matches("0x"))
-            .map_err(|_| format!("Invalid old signer address: {}", addr))?
-    } else {
-        fetch_signer_address(server, &app_id).await?
-    };
     let (new_signer, tee_url) = if let Some(addr) = new_signer_arg {
         let parsed = Address::from_str(addr.trim_start_matches("0x"))
             .map_err(|_| format!("Invalid new signer address: {}", addr))?;
@@ -2691,6 +2765,26 @@ async fn update_node_onchain(
     } else {
         let fetched = fetch_signer_address(server, &app_id).await?;
         (fetched, tee_url_arg.unwrap_or_else(|| server.to_string()))
+    };
+
+    // `--server` names the node that is *taking over* — that is where the new signer is read
+    // from. The one being replaced is dead by definition after a restart, so asking the same
+    // server for it would return the new signer and updateNode would revert with "old node
+    // not found": the only case where the default worked was the one where nothing needed
+    // changing.
+    let old_signer_addr = match old_signer_arg {
+        Some(addr) => Address::from_str(addr.trim_start_matches("0x"))
+            .map_err(|_| format!("Invalid old signer address: {}", addr))?,
+        None => match node_being_replaced(&rpc_url, &contract, &app_id, new_signer).await? {
+            Some(old) => old,
+            None => {
+                println!(
+                    "✓ Nothing to update: 0x{:x} is already the only node on chain for {}",
+                    new_signer, app_id
+                );
+                return Ok(());
+            }
+        },
     };
 
     // refresh this node's compose/volumes from its server; store as a per-node override
@@ -2937,5 +3031,54 @@ mod tests {
 
         let mounts = extract_volume_mounts(&compose_path, &content).unwrap();
         assert!(mounts.is_empty(), "named volumes and absolute paths must be skipped");
+    }
+}
+
+#[cfg(test)]
+mod replaced_node {
+    use super::*;
+    use ethers::types::Address;
+
+    fn a(b: u8) -> Address {
+        Address::from([b; 20])
+    }
+
+    #[test]
+    fn one_other_node_is_the_one_being_replaced() {
+        // The restart case: the chain holds the address of an instance that no longer exists,
+        // and only the chain still knows it. Nothing to guess, so no flag should be needed.
+        assert_eq!(
+            pick_replaced_node(&[a(1)], a(2), "app").unwrap(),
+            Some(a(1))
+        );
+    }
+
+    #[test]
+    fn a_signer_already_registered_alone_replaces_nothing() {
+        // Not an error: re-running after a successful update should be quiet, not fail.
+        assert_eq!(pick_replaced_node(&[a(2)], a(2), "app").unwrap(), None);
+    }
+
+    #[test]
+    fn no_nodes_at_all_replaces_nothing() {
+        // A registered app whose only node was removed. Adding is the right move.
+        assert_eq!(pick_replaced_node(&[], a(2), "app").unwrap(), None);
+    }
+
+    #[test]
+    fn several_other_nodes_refuse_to_guess() {
+        // Which of them died is not knowable here — they share an app and may share a teeUrl.
+        // Guessing would move the wrong node's stake, so the operator is asked instead.
+        let e = pick_replaced_node(&[a(1), a(3)], a(2), "app").unwrap_err();
+        assert!(e.contains("--old-signer"), "got: {}", e);
+        assert!(e.contains("2 other nodes"), "got: {}", e);
+    }
+
+    #[test]
+    fn the_signer_itself_is_never_counted_as_a_candidate() {
+        // Present among several: still two others, and it must not be offered as its own
+        // predecessor.
+        let e = pick_replaced_node(&[a(1), a(2), a(3)], a(2), "app").unwrap_err();
+        assert!(!e.contains(&format!("0x{:x}", a(2))), "got: {}", e);
     }
 }

--- a/tapp-cli/src/main.rs
+++ b/tapp-cli/src/main.rs
@@ -1370,20 +1370,17 @@ fn print_tls_binding(tls_public_key: &str, indent: &str) {
     if tls_public_key.is_empty() {
         return;
     }
-    println!("{}tls key    : {}  (sha256 of the public key, attested)", indent, tls_public_key);
+    println!("{}tls key     : {}  (sha256 of the public key, attested)", indent, tls_public_key);
+    println!("{}              compare against the endpoint with:", indent);
     println!(
-        "{}             compare against the endpoint with:",
+        "{}              openssl s_client -connect HOST:PORT </dev/null 2>/dev/null \\",
         indent
     );
     println!(
-        "{}             openssl s_client -connect HOST:PORT </dev/null 2>/dev/null \\",
+        "{}                | openssl x509 -pubkey -noout | openssl pkey -pubin -outform der \\",
         indent
     );
-    println!(
-        "{}               | openssl x509 -pubkey -noout | openssl pkey -pubin -outform der \\",
-        indent
-    );
-    println!("{}               | openssl dgst -sha256", indent);
+    println!("{}                | openssl dgst -sha256", indent);
 }
 
 fn boot_chain_line(executables: Option<i64>, show: bool) -> Option<String> {

--- a/tapp-cli/src/main.rs
+++ b/tapp-cli/src/main.rs
@@ -1366,21 +1366,31 @@ async fn get_app_info(server: &str, app_id: String) -> Result<(), Box<dyn std::e
 ///
 /// An empty value means the app has no TLS key yet, which is not a failure — most apps
 /// have never asked for one.
-fn print_tls_binding(tls_public_key: &str, indent: &str) {
+fn print_tls_binding(tls_public_key: &str, indent: &str, label_width: usize) {
     if tls_public_key.is_empty() {
         return;
     }
-    println!("{}tls key     : {}  (sha256 of the public key, attested)", indent, tls_public_key);
-    println!("{}              compare against the endpoint with:", indent);
+    // The two modes indent differently and label differently, so the width comes from
+    // the caller rather than being guessed — getting it wrong leaves one line visibly
+    // out of step with every other line around it.
+    let pad = " ".repeat(label_width + 2);
     println!(
-        "{}              openssl s_client -connect HOST:PORT </dev/null 2>/dev/null \\",
-        indent
+        "{}{:<w$}: {}  (sha256 of the public key, attested)",
+        indent,
+        "tls key",
+        tls_public_key,
+        w = label_width
+    );
+    println!("{}{}compare against the endpoint with:", indent, pad);
+    println!(
+        "{}{}openssl s_client -connect HOST:PORT </dev/null 2>/dev/null \\",
+        indent, pad
     );
     println!(
-        "{}                | openssl x509 -pubkey -noout | openssl pkey -pubin -outform der \\",
-        indent
+        "{}{}  | openssl x509 -pubkey -noout | openssl pkey -pubin -outform der \\",
+        indent, pad
     );
-    println!("{}                | openssl dgst -sha256", indent);
+    println!("{}{}  | openssl dgst -sha256", indent, pad);
 }
 
 fn boot_chain_line(executables: Option<i64>, show: bool) -> Option<String> {
@@ -1437,7 +1447,7 @@ async fn verify_app_cmd(
         println!("Verifying app: {}  (direct mode — no on-chain reconciliation)", app_id);
         println!("  server      : {}", d.server);
         println!("  signer      : {}  (attested in report_data)", d.signer);
-        print_tls_binding(&d.tls_public_key, "  ");
+        print_tls_binding(&d.tls_public_key, "  ", 12);
         println!("  AS          : ear.status={} tcb_status={} advisories={}", d.ear_status, d.tcb_status, d.advisories);
         if show_boot {
             if let Some(l) = boot_chain_line(d.boot_executables, show_boot) {
@@ -1495,7 +1505,7 @@ async fn verify_app_cmd(
             "    reconcile  : signer{} compose{} volumes{} image{} owner{}",
             yn(n.signer_ok), yn(n.compose_ok), yn(n.volumes_ok), yn(n.image_ok), owner_str
         );
-        print_tls_binding(&n.tls_public_key, "    ");
+        print_tls_binding(&n.tls_public_key, "    ", 11);
         if let Some(Err(claimed)) = &n.owner_claim {
             println!("    owner      : ✗ claim_config says {} but on-chain owner differs", claimed);
             all_ok = false;

--- a/tapp-cli/src/main.rs
+++ b/tapp-cli/src/main.rs
@@ -1748,6 +1748,12 @@ async fn get_app_tls_cert(
 
     println!("✓ {}", result.message);
     println!("  Public key sha256: {}", result.public_key_sha256);
+    println!("  Key source       : {}", result.key_source);
+    if result.key_source == "local" {
+        println!("  Bound to this instance, and regenerated when it restarts — do not pin it.");
+    } else {
+        println!("  Derived from KMS: stable across restarts and shared by every node of this app.");
+    }
     println!("  Issuer           : {}", result.issuer);
     if result.issuer == "self-signed" {
         println!(

--- a/tapp-cli/src/main.rs
+++ b/tapp-cli/src/main.rs
@@ -201,6 +201,11 @@ enum Commands {
         /// Application ID
         #[arg(short, long)]
         app_id: String,
+
+        /// Challenge, hex, up to 64 bytes. The server echoes it into report_data, which
+        /// is what distinguishes a quote made for this request from a cached one.
+        #[arg(long)]
+        nonce: Option<String>,
     },
 
     /// Get application public key
@@ -208,10 +213,6 @@ enum Commands {
         /// Application ID
         #[arg(short, long)]
         app_id: String,
-
-        /// Key type (default: ethereum)
-        #[arg(short = 't', long, default_value = "ethereum")]
-        key_type: String,
 
         /// Use X25519 key pair
         #[arg(long)]
@@ -640,15 +641,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let private_key = require_private_key(&cli.private_key)?;
             get_app_container_status(&cli.server, app_id, private_key).await?;
         }
-        Commands::GetEvidence { app_id } => {
-            get_evidence(&cli.server, app_id).await?;
+        Commands::GetEvidence { app_id, nonce } => {
+            get_evidence(&cli.server, app_id, nonce).await?;
         }
-        Commands::GetAppKey {
-            app_id,
-            key_type,
-            x25519,
-        } => {
-            get_app_key(&cli.server, app_id, key_type, x25519).await?;
+        Commands::GetAppKey { app_id, x25519 } => {
+            get_app_key(&cli.server, app_id, x25519).await?;
         }
         Commands::GetAppSecretKey {
             app_id,
@@ -1559,16 +1556,65 @@ async fn get_app_container_status(
     Ok(())
 }
 
-async fn get_evidence(server: &str, app_id: String) -> Result<(), Box<dyn std::error::Error>> {
+async fn get_evidence(
+    server: &str,
+    app_id: String,
+    nonce_hex: Option<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
     let mut client = create_client(server).await?;
 
-    let request = Request::new(GetEvidenceRequest { app_id });
+    let nonce = match nonce_hex.as_deref() {
+        Some(h) => hex::decode(h.trim_start_matches("0x"))
+            .map_err(|e| format!("--nonce must be hex: {}", e))?,
+        None => Vec::new(),
+    };
+
+    let request = Request::new(GetEvidenceRequest {
+        app_id,
+        nonce: nonce.clone(),
+    });
 
     let response = client.get_evidence(request).await?;
     let result = response.into_inner();
 
     println!("✓ Evidence generated successfully");
     println!("  TEE Type: {}", result.tee_type);
+
+    // Show what report_data committed to, so the challenge can be checked by eye rather
+    // than only by verify-app. A server that predates the field says so plainly here
+    // instead of looking like a failure.
+    match serde_json::from_slice::<serde_json::Value>(&result.evidence) {
+        Ok(j) => match j[tapp_common::report_data::EVIDENCE_FIELD].as_str() {
+            Some(b64) => match base64::decode(b64) {
+                Ok(bytes) => {
+                    println!("  runtime_data: {}", String::from_utf8_lossy(&bytes));
+                    println!(
+                        "  report_data : {}",
+                        hex::encode(tapp_common::report_data::report_data_of(&bytes))
+                    );
+                    if !nonce.is_empty() {
+                        let parsed: tapp_common::report_data::RuntimeData =
+                            serde_json::from_slice(&bytes)?;
+                        let echoed = tapp_common::report_data::strip_hex(&parsed.nonce)
+                            .eq_ignore_ascii_case(&hex::encode(&nonce));
+                        println!(
+                            "  challenge   : {}",
+                            if echoed {
+                                "echoed — this quote was produced for this request"
+                            } else {
+                                "NOT echoed — this quote was not produced for this request"
+                            }
+                        );
+                    }
+                }
+                Err(e) => println!("  runtime_data: unreadable ({})", e),
+            },
+            None if nonce.is_empty() => {}
+            None => println!("  challenge   : ignored — this server predates the nonce field"),
+        },
+        Err(_) => println!("  (evidence is not JSON; nothing to inspect)"),
+    }
+
     println!("  Evidence (hex): {}", hex::encode(&result.evidence));
     println!("  Evidence (base64): {}", base64::encode(&result.evidence));
 
@@ -1578,14 +1624,16 @@ async fn get_evidence(server: &str, app_id: String) -> Result<(), Box<dyn std::e
 async fn get_app_key(
     server: &str,
     app_id: String,
-    key_type: String,
     x25519: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let mut client = create_client(server).await?;
 
+    // key_type is left empty: the server treats that as "ethereum", the only kind that
+    // exists. There used to be a --key-type flag here that was sent but ignored, so
+    // `--key-type rsa` printed "rsa" over ethereum key material.
     let request = Request::new(GetAppKeyRequest {
         app_id: app_id.clone(),
-        key_type: key_type.clone(),
+        key_type: String::new(),
         additional_data: vec![],
         kbs_resource_uri: String::new(),
         x25519,
@@ -1601,11 +1649,10 @@ async fn get_app_key(
 
     println!("✓ Application key retrieved");
     println!("  App ID: {}", app_id);
-    println!("  Key Type: {}", key_type);
     println!("  Key Source: {}", result.key_source);
     println!("  Public Key (hex): 0x{}", hex::encode(&result.public_key));
 
-    if key_type == "ethereum" && !result.eth_address.is_empty() {
+    if !result.eth_address.is_empty() {
         println!("  Ethereum Address: 0x{}", hex::encode(&result.eth_address));
     }
 

--- a/tapp-cli/src/main.rs
+++ b/tapp-cli/src/main.rs
@@ -1344,6 +1344,35 @@ async fn get_app_info(server: &str, app_id: String) -> Result<(), Box<dyn std::e
 /// Returns None when no policy was selected (`show=false`) — the AS default policy's
 /// executables claim is not our boot-chain check, so we don't show it. The caller adds
 /// section-appropriate indentation.
+/// What the quote vouches for about the app's TLS key.
+///
+/// Printed as something to compare rather than as a pass/fail, because this command never
+/// touches the app's service port — it cannot know which key is actually being served. The
+/// comparison is the reader's to make, and it is one command: connect, take the public key
+/// out of the certificate, hash it.
+///
+/// An empty value means the app has no TLS key yet, which is not a failure — most apps
+/// have never asked for one.
+fn print_tls_binding(tls_public_key: &str, indent: &str) {
+    if tls_public_key.is_empty() {
+        return;
+    }
+    println!("{}tls key    : {}  (sha256 of the public key, attested)", indent, tls_public_key);
+    println!(
+        "{}             compare against the endpoint with:",
+        indent
+    );
+    println!(
+        "{}             openssl s_client -connect HOST:PORT </dev/null 2>/dev/null \\",
+        indent
+    );
+    println!(
+        "{}               | openssl x509 -pubkey -noout | openssl pkey -pubin -outform der \\",
+        indent
+    );
+    println!("{}               | openssl dgst -sha256", indent);
+}
+
 fn boot_chain_line(executables: Option<i64>, show: bool) -> Option<String> {
     use tapp_common::verify::EXECUTABLES_MATCHED;
     if !show {
@@ -1398,6 +1427,7 @@ async fn verify_app_cmd(
         println!("Verifying app: {}  (direct mode — no on-chain reconciliation)", app_id);
         println!("  server      : {}", d.server);
         println!("  signer      : {}  (attested in report_data)", d.signer);
+        print_tls_binding(&d.tls_public_key, "  ");
         println!("  AS          : ear.status={} tcb_status={} advisories={}", d.ear_status, d.tcb_status, d.advisories);
         if show_boot {
             if let Some(l) = boot_chain_line(d.boot_executables, show_boot) {
@@ -1455,6 +1485,7 @@ async fn verify_app_cmd(
             "    reconcile  : signer{} compose{} volumes{} image{} owner{}",
             yn(n.signer_ok), yn(n.compose_ok), yn(n.volumes_ok), yn(n.image_ok), owner_str
         );
+        print_tls_binding(&n.tls_public_key, "    ");
         if let Some(Err(claimed)) = &n.owner_claim {
             println!("    owner      : ✗ claim_config says {} but on-chain owner differs", claimed);
             all_ok = false;

--- a/tapp-common/Cargo.toml
+++ b/tapp-common/Cargo.toml
@@ -31,6 +31,8 @@ sha3 = "0.10"
 hex = "0.4"
 k256 = { version = "0.13", features = ["ecdsa", "std"] }
 x25519-dalek = { version = "2.0", features = ["static_secrets"] }
+# Challenges for evidence freshness — must be random, never a counter or a clock.
+rand = "0.8.5"
 
 # Logging (used by app_key, onchain, verify)
 tracing = "0.1"

--- a/tapp-common/proto/tapp_service.proto
+++ b/tapp-common/proto/tapp_service.proto
@@ -223,8 +223,17 @@ message ListAppMeasurementsResponse {
 // Get Evidence Messages
 message GetEvidenceRequest {
   string app_id = 1;  // Application identifier
-                      // The TEE-derived signer EVM address of the app will
-                      // be automatically used as report_data
+
+  // Optional challenge, at most 64 bytes, echoed into the quote's report_data.
+  //
+  // A quote says nothing about when it was produced, so a cached blob looks exactly
+  // like a fresh one. A caller that sends a random value per request can tell them
+  // apart. A caller that fetches once and serves the result to many readers (and
+  // reports it "as of" a timestamp) sends nothing and leaves the field out.
+  //
+  // report_data is sha512 of the `runtime_data` object returned alongside the quote;
+  // see tapp_common::report_data.
+  bytes nonce = 2;
 }
 
 message GetEvidenceResponse {
@@ -239,7 +248,10 @@ message GetEvidenceResponse {
 // Get App Key Messages (replaces GetPubkey)
 message GetAppKeyRequest {
   string app_id = 1;            // Application identifier
-  string key_type = 2;          // Key type: "ethereum", "rsa", "ec"
+  // Only "ethereum" is implemented; empty means "ethereum". Anything else is
+  // refused rather than silently substituted. "rsa"/"ec" were advertised here for a
+  // long time and never existed.
+  string key_type = 2;
   bytes additional_data = 3;    // Additional binding data
   string kbs_resource_uri = 4;  // KBS resource URI for key material
   bool x25519 = 5;              // Use X25519 key pair
@@ -261,7 +273,7 @@ message GetAppKeyResponse {
 // Get App Secret Key Messages (local access only)
 message GetAppSecretKeyRequest {
   string app_id = 1;    // Application identifier
-  string key_type = 2;  // Key type: "ethereum", "rsa", "ec"
+  string key_type = 2;  // Only "ethereum" is implemented; empty means "ethereum"
   bool x25519 = 3;      // Use X25519 key pair
 }
 

--- a/tapp-common/proto/tapp_service.proto
+++ b/tapp-common/proto/tapp_service.proto
@@ -26,6 +26,11 @@ service TappService {
   // Get application secret key (private key) - local access only
   rpc GetAppSecretKey(GetAppSecretKeyRequest) returns (GetAppSecretKeyResponse);
 
+  // Get the app's TLS key and certificate - local access only.
+  // The key is derived from KMS, so it is the same on every restart and on every node
+  // of the app; the app just writes two PEM files and points its server at them.
+  rpc GetAppTlsCert(GetAppTlsCertRequest) returns (GetAppTlsCertResponse);
+
   // Get application information
   rpc GetAppInfo(GetAppInfoRequest) returns (GetAppInfoResponse);
 
@@ -268,6 +273,35 @@ message GetAppKeyResponse {
   bytes x25519_public_key = 5;  // 32-byte X25519 public key
   // Key provenance
   string key_source = 6;  // Source: "kbs", "in-memory"
+}
+
+// Get App TLS Cert Messages (local access only — carries a private key)
+message GetAppTlsCertRequest {
+  string app_id = 1;  // Application identifier
+}
+
+message GetAppTlsCertResponse {
+  bool success = 1;
+  string message = 2;
+
+  // The two files an ordinary TLS server wants. No crypto work left for the app.
+  string key_pem = 3;
+  string cert_pem = 4;
+
+  // "ca" when a CA signed it, "self-signed" when none is configured. Self-signed is
+  // not a lesser certificate here: what a verifier checks is the public key against
+  // the quote, not the issuer. The issuer matters only to clients that will not do
+  // that check — browsers, anything using a system trust store.
+  string issuer = 5;
+
+  // Always present, so the certificate can be reissued by whatever authority the
+  // deployer prefers (Let's Encrypt, their own CA) without asking for the key again.
+  string csr_pem = 6;
+
+  // sha256 of the SubjectPublicKeyInfo, hex. This is the value the quote's report_data
+  // commits to, so a verifier compares this against the key it was handed during the
+  // handshake. Returned here to save every caller re-deriving it.
+  string public_key_sha256 = 7;
 }
 
 // Get App Secret Key Messages (local access only)

--- a/tapp-common/proto/tapp_service.proto
+++ b/tapp-common/proto/tapp_service.proto
@@ -27,8 +27,9 @@ service TappService {
   rpc GetAppSecretKey(GetAppSecretKeyRequest) returns (GetAppSecretKeyResponse);
 
   // Get the app's TLS key and certificate - local access only.
-  // The key is derived from KMS, so it is the same on every restart and on every node
-  // of the app; the app just writes two PEM files and points its server at them.
+  // The app writes two PEM files and points its server at them; no crypto work is left
+  // to it. Where the key comes from is a deployment choice — see key_source in the
+  // response, which decides whether the public key survives a restart.
   rpc GetAppTlsCert(GetAppTlsCertRequest) returns (GetAppTlsCertResponse);
 
   // Get application information
@@ -302,6 +303,12 @@ message GetAppTlsCertResponse {
   // commits to, so a verifier compares this against the key it was handed during the
   // handshake. Returned here to save every caller re-deriving it.
   string public_key_sha256 = 7;
+
+  // "local" or "kms" — where the private key came from. This decides whether the public
+  // key survives a restart, so a client choosing to pin it needs to know: "local" is
+  // bound to this instance and changes when it restarts, "kms" is stable and shared by
+  // every node of the app.
+  string key_source = 8;
 }
 
 // Get App Secret Key Messages (local access only)

--- a/tapp-common/proto/tapp_service.proto
+++ b/tapp-common/proto/tapp_service.proto
@@ -704,6 +704,16 @@ message ClaimConfigRequest {
   // When provided, the KMS client is initialized on this call (no config.toml
   // [kbs] section needed). Ignored if KBS was already configured at startup.
   repeated string kbs_node_urls = 3;
+
+  // Optional: where app TLS private keys come from — "local" (default) or "kms".
+  //
+  // Here rather than in config.toml for the same reason the owner is: config.toml
+  // lives in the CVM image, so a field there means a separate image and a separate
+  // set of reference values per choice. Claimed instead, the image stays generic and
+  // the choice becomes a measured fact a verifier can read out of the event log —
+  // which matters, because it decides whether the attested public key survives a
+  // restart.
+  string tls_key_source = 4;
 }
 
 message ClaimConfigResponse {

--- a/tapp-common/src/lib.rs
+++ b/tapp-common/src/lib.rs
@@ -5,6 +5,7 @@
 pub mod error;
 pub mod onchain;
 pub mod app_key;
+pub mod report_data;
 pub mod verify;
 pub mod compat;
 

--- a/tapp-common/src/report_data.rs
+++ b/tapp-common/src/report_data.rs
@@ -37,15 +37,15 @@ pub const MAX_NONCE_LEN: usize = 64;
 /// is unused.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RuntimeData {
-    /// The app's TEE-derived signer, `0x…`. This is the identity TappRegistry records.
-    pub signer: String,
-
     /// Caller-supplied challenge, `0x…`. Evidence is self-authenticating but undated:
     /// nothing in a quote says when it was produced, so a cached copy is indistinguishable
     /// from a fresh one. A caller that sends a random value per request can tell them
     /// apart; one that serves cached results to many readers sends nothing.
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub nonce: String,
+
+    /// The app's TEE-derived signer, `0x…`. This is the identity TappRegistry records.
+    pub signer: String,
 
     /// sha256 of the app's TLS public key, `0x…`. Reserved — populated once apps derive a
     /// TLS key, at which point this is what lets a client tie the certificate it was
@@ -78,12 +78,12 @@ impl RuntimeData {
             .into());
         }
         Ok(Self {
-            signer: format!("0x{}", hex::encode(signer_eth_address)),
             nonce: if nonce.is_empty() {
                 String::new()
             } else {
                 format!("0x{}", hex::encode(nonce))
             },
+            signer: format!("0x{}", hex::encode(signer_eth_address)),
             tls_public_key: String::new(),
         })
     }

--- a/tapp-common/src/report_data.rs
+++ b/tapp-common/src/report_data.rs
@@ -1,0 +1,159 @@
+//! What a quote's 64-byte `report_data` commits to.
+//!
+//! It used to be the 20-byte signer address, left-aligned and zero-padded. That made a
+//! quote self-describing — you could read the signer straight out of it — but it left
+//! nothing to extend with, and 20 + a 32-byte binding + a challenge already overflows
+//! 64 bytes.
+//!
+//! So `report_data` is now `sha512` of a small JSON object that travels beside the quote
+//! inside the evidence. Two consequences worth knowing:
+//!
+//! - **A quote alone no longer names its signer.** The structure must accompany it.
+//!   Evidence has always been carried as `{quote, cc_eventlog}` JSON, so this is a third
+//!   field of the same object and nothing in the system passes a bare quote.
+//! - **Verifiers hash the bytes exactly as transmitted** and never re-serialise them, so
+//!   there is no canonical form for the two sides to agree on and drift apart over. The
+//!   `RuntimeData` struct is a convenience for reading the fields, never a re-encoder.
+//!
+//! `sha512` is not arbitrary: TDX `report_data` is 64 bytes and sha512 fills it exactly,
+//! which is also what CoCo-AS expects when it is handed `runtime_data` and asked to check
+//! the binding itself.
+
+use crate::error::{DockerError, TappResult};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha512};
+
+/// Field name under which the hashed bytes travel inside the evidence JSON.
+pub const EVIDENCE_FIELD: &str = "runtime_data";
+
+/// Longest challenge accepted, in bytes. A caller only needs enough to be unguessable;
+/// the cap exists so a request cannot inflate every quote this node produces.
+pub const MAX_NONCE_LEN: usize = 64;
+
+/// The object `report_data` is the hash of.
+///
+/// Empty fields are omitted rather than serialised as `""`, so evidence produced before
+/// a field existed and evidence produced after it are byte-identical whenever the field
+/// is unused.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeData {
+    /// The app's TEE-derived signer, `0x…`. This is the identity TappRegistry records.
+    pub signer: String,
+
+    /// Caller-supplied challenge, `0x…`. Evidence is self-authenticating but undated:
+    /// nothing in a quote says when it was produced, so a cached copy is indistinguishable
+    /// from a fresh one. A caller that sends a random value per request can tell them
+    /// apart; one that serves cached results to many readers sends nothing.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub nonce: String,
+
+    /// sha256 of the app's TLS public key, `0x…`. Reserved — populated once apps derive a
+    /// TLS key, at which point this is what lets a client tie the certificate it was
+    /// handed during a handshake to a TEE running this app.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub tls_public_key: String,
+}
+
+impl RuntimeData {
+    pub fn new(signer_eth_address: &[u8], nonce: &[u8]) -> TappResult<Self> {
+        if signer_eth_address.len() != 20 {
+            return Err(DockerError::ContainerOperationFailed {
+                operation: "runtime_data".to_string(),
+                reason: format!(
+                    "signer must be 20 bytes, got {}",
+                    signer_eth_address.len()
+                ),
+            }
+            .into());
+        }
+        if nonce.len() > MAX_NONCE_LEN {
+            return Err(DockerError::ContainerOperationFailed {
+                operation: "runtime_data".to_string(),
+                reason: format!(
+                    "nonce must be at most {} bytes, got {}",
+                    MAX_NONCE_LEN,
+                    nonce.len()
+                ),
+            }
+            .into());
+        }
+        Ok(Self {
+            signer: format!("0x{}", hex::encode(signer_eth_address)),
+            nonce: if nonce.is_empty() {
+                String::new()
+            } else {
+                format!("0x{}", hex::encode(nonce))
+            },
+            tls_public_key: String::new(),
+        })
+    }
+
+    /// Serialise, and return the bytes together with the `report_data` they produce.
+    /// Callers must transmit *these* bytes; re-serialising elsewhere would change them.
+    pub fn seal(&self) -> TappResult<(Vec<u8>, Vec<u8>)> {
+        let bytes =
+            serde_json::to_vec(self).map_err(|e| DockerError::ContainerOperationFailed {
+                operation: "runtime_data".to_string(),
+                reason: format!("serialise: {}", e),
+            })?;
+        let report_data = report_data_of(&bytes);
+        Ok((bytes, report_data))
+    }
+}
+
+/// The `report_data` a given set of transmitted bytes commits to.
+pub fn report_data_of(runtime_data: &[u8]) -> Vec<u8> {
+    Sha512::digest(runtime_data).to_vec()
+}
+
+/// Hex without the `0x`, lowercase — for comparing a field against raw bytes.
+pub fn strip_hex(s: &str) -> &str {
+    s.strip_prefix("0x").unwrap_or(s)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SIGNER: [u8; 20] = [0xab; 20];
+
+    #[test]
+    fn report_data_is_exactly_64_bytes_so_it_fills_the_quote_field() {
+        let (_, rd) = RuntimeData::new(&SIGNER, &[]).unwrap().seal().unwrap();
+        assert_eq!(rd.len(), 64);
+    }
+
+    #[test]
+    fn an_absent_nonce_is_omitted_not_empty_string() {
+        let (bytes, _) = RuntimeData::new(&SIGNER, &[]).unwrap().seal().unwrap();
+        let s = String::from_utf8(bytes).unwrap();
+        assert!(!s.contains("nonce"), "got {}", s);
+        assert!(!s.contains("tls_public_key"), "got {}", s);
+    }
+
+    #[test]
+    fn a_different_nonce_gives_a_different_report_data() {
+        let (_, a) = RuntimeData::new(&SIGNER, b"one").unwrap().seal().unwrap();
+        let (_, b) = RuntimeData::new(&SIGNER, b"two").unwrap().seal().unwrap();
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn the_transmitted_bytes_reproduce_the_report_data() {
+        let (bytes, rd) = RuntimeData::new(&SIGNER, b"chal").unwrap().seal().unwrap();
+        assert_eq!(report_data_of(&bytes), rd);
+    }
+
+    #[test]
+    fn a_verifier_reads_the_fields_back_without_re_encoding() {
+        let (bytes, _) = RuntimeData::new(&SIGNER, b"chal").unwrap().seal().unwrap();
+        let parsed: RuntimeData = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(strip_hex(&parsed.signer), hex::encode(SIGNER));
+        assert_eq!(strip_hex(&parsed.nonce), hex::encode(b"chal"));
+    }
+
+    #[test]
+    fn an_oversized_nonce_is_refused_rather_than_truncated() {
+        assert!(RuntimeData::new(&SIGNER, &[0u8; MAX_NONCE_LEN + 1]).is_err());
+    }
+}

--- a/tapp-common/src/verify.rs
+++ b/tapp-common/src/verify.rs
@@ -27,6 +27,11 @@ pub struct NodeVerdict {
     pub tcb_status: String,
     pub advisories: usize,
     pub signer_ok: bool,  // report_data binds the on-chain signer
+    /// sha256 of the TLS public key the quote vouches for, `0x…`. Empty when the app has
+    /// no TLS key. A client that compares this against the certificate it was served
+    /// during a handshake learns the peer holds a key attested inside this TEE — which is
+    /// the whole of layer-1 verification, and needs no CA.
+    pub tls_public_key: String,
     pub compose_ok: bool, // start_app compose == node effective compose
     pub volumes_ok: bool,
     pub image_ok: bool,
@@ -62,6 +67,9 @@ struct StartAppMeasure {
 struct Attested {
     /// The signer the quote names, `0x…`. Empty if it could not be read.
     signer: String,
+    /// sha256 of the app's TLS public key, `0x…`, empty when the app has no TLS key yet.
+    /// A client compares this against the key it was handed during a handshake.
+    tls_public_key: String,
     /// `None` when no challenge was sent or the server predates the field, so a caller
     /// that does not care about freshness is never reported as failing.
     fresh: Option<bool>,
@@ -90,6 +98,7 @@ impl Attested {
 fn read_report_data(evidence: &serde_json::Value, quote_b64: &str, nonce: &[u8]) -> Attested {
     let mut a = Attested {
         signer: String::new(),
+        tls_public_key: String::new(),
         fresh: None,
         structured: false,
         note: String::new(),
@@ -132,6 +141,7 @@ fn read_report_data(evidence: &serde_json::Value, quote_b64: &str, nonce: &[u8])
     };
 
     a.signer = parsed.signer;
+    a.tls_public_key = parsed.tls_public_key;
     if !nonce.is_empty() {
         let echoed = crate::report_data::strip_hex(&parsed.nonce)
             .eq_ignore_ascii_case(&hex::encode(nonce));
@@ -481,6 +491,8 @@ async fn fetch_evidence(tee_url: &str, app_id: &str, nonce: &[u8]) -> Result<Vec
 pub struct DirectVerdict {
     pub server: String,
     pub signer: String, // from quote report_data (0x…), as attested (not reconciled)
+    /// sha256 of the attested TLS public key, `0x…`. Empty when the app has no TLS key.
+    pub tls_public_key: String,
     pub ear_status: String,
     pub tcb_status: String,
     pub advisories: usize,
@@ -503,6 +515,7 @@ pub async fn verify_node_direct(
     let mut v = DirectVerdict {
         server: server.to_string(),
         signer: String::new(),
+        tls_public_key: String::new(),
         ear_status: "-".to_string(),
         tcb_status: "-".to_string(),
         advisories: 0,
@@ -524,6 +537,7 @@ pub async fn verify_node_direct(
     // is that the app may not be registered — so report what the node attested.
     let attested = read_report_data(&j, quote_b64, &nonce);
     v.signer = attested.signer.clone();
+    v.tls_public_key = attested.tls_public_key.clone();
     v.note = attested.note.clone();
 
     match verify_with_as(as_endpoint, &raw, policy_ids).await {
@@ -590,6 +604,7 @@ pub async fn verify_app(
             tcb_status: "-".to_string(),
             advisories: 0,
             signer_ok: false,
+            tls_public_key: String::new(),
             compose_ok: false,
             volumes_ok: false,
             image_ok: false,
@@ -636,6 +651,7 @@ pub async fn verify_app(
         // ④a signer binding: the quote names the signer the chain registered
         let attested = read_report_data(&j, quote_b64, &nonce);
         v.signer_ok = attested.is(signer.as_bytes());
+        v.tls_public_key = attested.tls_public_key.clone();
         v.note = attested.note.clone();
 
         // ③ AS quote verification

--- a/tapp-common/src/verify.rs
+++ b/tapp-common/src/verify.rs
@@ -58,6 +58,93 @@ struct StartAppMeasure {
     image_hash: HashMap<String, String>,   // service -> "sha256:…"
 }
 
+/// What a quote's `report_data` commits to, read in whichever era applies.
+struct Attested {
+    /// The signer the quote names, `0x…`. Empty if it could not be read.
+    signer: String,
+    /// `None` when no challenge was sent or the server predates the field, so a caller
+    /// that does not care about freshness is never reported as failing.
+    fresh: Option<bool>,
+    /// False means the old signer-only `report_data`, which carries no challenge at all.
+    structured: bool,
+    note: String,
+}
+
+impl Attested {
+    /// True when `signer` is the address the caller expected.
+    fn is(&self, expected: &[u8]) -> bool {
+        crate::report_data::strip_hex(&self.signer).eq_ignore_ascii_case(&hex::encode(expected))
+    }
+}
+
+/// Read the signer, and the challenge if there is one, out of a quote.
+///
+/// Which era applies is decided by whether the evidence carries a `runtime_data` field —
+/// never guessed from the bytes:
+///
+/// - **With it**, `report_data` is `sha512(runtime_data)`. Recompute from the bytes as
+///   received (never re-serialise) and read the fields out of the structure. Confirming
+///   the challenge came back is the only way to tell a fresh quote from a replayed one.
+/// - **Without it**, `report_data` is the bare 20-byte address. Take the leading 20
+///   bytes — that is where every server that produced this format put it.
+fn read_report_data(evidence: &serde_json::Value, quote_b64: &str, nonce: &[u8]) -> Attested {
+    let mut a = Attested {
+        signer: String::new(),
+        fresh: None,
+        structured: false,
+        note: String::new(),
+    };
+
+    let rd = match quote_report_data(quote_b64) {
+        Ok(rd) => rd,
+        Err(e) => {
+            a.note = format!("quote parse failed: {}; ", e);
+            return a;
+        }
+    };
+
+    let Some(rdata_b64) = evidence[crate::report_data::EVIDENCE_FIELD].as_str() else {
+        a.signer = format!("0x{}", hex::encode(&rd[..20]));
+        if !nonce.is_empty() {
+            a.note = "server predates the challenge field, freshness unproven; ".to_string();
+        }
+        return a;
+    };
+    a.structured = true;
+
+    let bytes = match B64.decode(rdata_b64) {
+        Ok(b) => b,
+        Err(e) => {
+            a.note = format!("runtime_data b64: {}; ", e);
+            return a;
+        }
+    };
+    if crate::report_data::report_data_of(&bytes) != rd {
+        a.note = "runtime_data does not hash to the quote's report_data; ".to_string();
+        return a;
+    }
+    let parsed: crate::report_data::RuntimeData = match serde_json::from_slice(&bytes) {
+        Ok(p) => p,
+        Err(e) => {
+            a.note = format!("runtime_data parse: {}; ", e);
+            return a;
+        }
+    };
+
+    a.signer = parsed.signer;
+    if !nonce.is_empty() {
+        let echoed = crate::report_data::strip_hex(&parsed.nonce)
+            .eq_ignore_ascii_case(&hex::encode(nonce));
+        a.fresh = Some(echoed);
+        if !echoed {
+            a.note =
+                "challenge not echoed — this evidence was not produced for this request; "
+                    .to_string();
+        }
+    }
+    a
+}
+
 /// report_data (64 bytes) from a TDX quote, header offset resolved by version (v4=48, v5=54).
 fn quote_report_data(quote_b64: &str) -> Result<Vec<u8>> {
     let q = B64.decode(quote_b64).map_err(|e| anyhow!("quote b64: {}", e))?;
@@ -328,7 +415,11 @@ async fn verify_with_as(
         verification_requests: vec![IndividualAttestationRequest {
             tee: "tdx".to_string(),
             evidence: B64URL.encode(raw_evidence),
-            runtime_data: None, // no nonce binding for pre-generated, signer-bound evidence
+            // Left unset deliberately. report_data is now sha512 of the runtime_data we
+            // could hand over here, which would make the AS check the binding for us — but
+            // only if its hash choice matches ours, and that is unconfirmed. Until then we
+            // check it ourselves in read_report_data, which loses nothing.
+            runtime_data: None,
             init_data: None,
             runtime_data_hash_algorithm: String::new(),
         }],
@@ -360,13 +451,23 @@ async fn verify_with_as(
     Ok(AsVerdict { ear_status, tcb_status: tcb, advisories: adv, executables, boot_measurements: vec![] })
 }
 
-async fn fetch_evidence(tee_url: &str, app_id: &str) -> Result<Vec<u8>> {
+/// A fresh challenge. Random per call, never a counter or a timestamp: the point is that
+/// the node cannot have produced this quote before we asked.
+fn fresh_nonce() -> Vec<u8> {
+    use rand::RngCore;
+    let mut n = vec![0u8; 16];
+    rand::thread_rng().fill_bytes(&mut n);
+    n
+}
+
+async fn fetch_evidence(tee_url: &str, app_id: &str, nonce: &[u8]) -> Result<Vec<u8>> {
     let mut client = TappServiceClient::connect(tee_url.to_string())
         .await
         .map_err(|e| anyhow!("connect {}: {}", tee_url, e))?;
     let resp = client
         .get_evidence(tonic::Request::new(GetEvidenceRequest {
             app_id: app_id.to_owned(),
+            nonce: nonce.to_vec(),
         }))
         .await
         .map_err(|e| anyhow!("{}", e))?
@@ -413,16 +514,17 @@ pub async fn verify_node_direct(
         note: String::new(),
     };
 
-    let raw = fetch_evidence(server, app_id).await?;
+    let nonce = fresh_nonce();
+    let raw = fetch_evidence(server, app_id, &nonce).await?;
     let j: serde_json::Value = serde_json::from_slice(&raw)?;
     let quote_b64 = j["quote"].as_str().unwrap_or("");
     let cc_b64 = j["cc_eventlog"].as_str().unwrap_or("");
 
-    if let Ok(rd) = quote_report_data(quote_b64) {
-        v.signer = format!("0x{}", hex::encode(&rd[..20]));
-    } else {
-        v.note = "quote parse failed; ".to_string();
-    }
+    // There is no on-chain signer to compare against here — the whole point of this path
+    // is that the app may not be registered — so report what the node attested.
+    let attested = read_report_data(&j, quote_b64, &nonce);
+    v.signer = attested.signer.clone();
+    v.note = attested.note.clone();
 
     match verify_with_as(as_endpoint, &raw, policy_ids).await {
         Ok(av) => {
@@ -509,8 +611,9 @@ pub async fn verify_app(
             };
         v.tee_url = tee_url.clone();
 
-        // ② fetch evidence
-        let raw = match fetch_evidence(&tee_url, app_id).await {
+        // ② fetch evidence, with a challenge so a cached blob is distinguishable
+        let nonce = fresh_nonce();
+        let raw = match fetch_evidence(&tee_url, app_id, &nonce).await {
             Ok(b) => b,
             Err(e) => {
                 v.note = format!("get-evidence failed: {}", e);
@@ -530,13 +633,10 @@ pub async fn verify_app(
         let quote_b64 = j["quote"].as_str().unwrap_or("");
         let cc_b64 = j["cc_eventlog"].as_str().unwrap_or("");
 
-        // ④a signer binding: on-chain signer (20 bytes) present in report_data
-        if let Ok(rd) = quote_report_data(quote_b64) {
-            let needle = signer.as_bytes();
-            v.signer_ok = rd.windows(needle.len()).any(|w| w == needle);
-        } else {
-            v.note = "quote parse failed; ".to_string();
-        }
+        // ④a signer binding: the quote names the signer the chain registered
+        let attested = read_report_data(&j, quote_b64, &nonce);
+        v.signer_ok = attested.is(signer.as_bytes());
+        v.note = attested.note.clone();
 
         // ③ AS quote verification
         match verify_with_as(as_endpoint, &raw, policy_ids).await {
@@ -589,4 +689,88 @@ pub async fn verify_app(
         app_id: app_id.to_string(),
         nodes,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SIGNER: [u8; 20] = [0x11; 20];
+
+    /// Smallest thing `quote_report_data` will parse: v4 header (48 bytes) followed by a
+    /// 584-byte body whose last 64 bytes are report_data.
+    fn quote_with(report_data: &[u8]) -> String {
+        let mut q = vec![0u8; 48 + 584];
+        q[0..2].copy_from_slice(&4u16.to_le_bytes());
+        q[48 + 520..48 + 584].copy_from_slice(report_data);
+        B64.encode(q)
+    }
+
+    fn legacy_report_data(signer: &[u8]) -> Vec<u8> {
+        let mut rd = vec![0u8; 64];
+        rd[..signer.len()].copy_from_slice(signer);
+        rd
+    }
+
+    #[test]
+    fn a_server_that_predates_runtime_data_still_has_its_signer_read() {
+        let quote = quote_with(&legacy_report_data(&SIGNER));
+        let a = read_report_data(&serde_json::json!({}), &quote, &[]);
+        assert!(a.is(&SIGNER));
+        assert!(!a.structured);
+        assert_eq!(a.fresh, None);
+        assert!(a.note.is_empty());
+    }
+
+    #[test]
+    fn sending_a_challenge_to_an_old_server_says_so_instead_of_failing_the_signer() {
+        let quote = quote_with(&legacy_report_data(&SIGNER));
+        let a = read_report_data(&serde_json::json!({}), &quote, b"chal");
+        assert!(a.is(&SIGNER), "the signer binding still holds");
+        assert_eq!(a.fresh, None, "not a failure — the server cannot answer it");
+        assert!(a.note.contains("predates"), "got {}", a.note);
+    }
+
+    #[test]
+    fn an_echoed_challenge_proves_the_quote_was_made_for_this_request() {
+        let rdata = crate::report_data::RuntimeData::new(&SIGNER, b"chal").unwrap();
+        let (bytes, rd) = rdata.seal().unwrap();
+        let ev = serde_json::json!({ crate::report_data::EVIDENCE_FIELD: B64.encode(&bytes) });
+        let a = read_report_data(&ev, &quote_with(&rd), b"chal");
+        assert!(a.is(&SIGNER));
+        assert!(a.structured);
+        assert_eq!(a.fresh, Some(true));
+        assert!(a.note.is_empty());
+    }
+
+    #[test]
+    fn a_replayed_quote_is_caught_by_the_challenge_not_by_the_signer() {
+        // Evidence produced for someone else's challenge: signer still binds, freshness does not.
+        let rdata = crate::report_data::RuntimeData::new(&SIGNER, b"theirs").unwrap();
+        let (bytes, rd) = rdata.seal().unwrap();
+        let ev = serde_json::json!({ crate::report_data::EVIDENCE_FIELD: B64.encode(&bytes) });
+        let a = read_report_data(&ev, &quote_with(&rd), b"mine");
+        assert!(a.is(&SIGNER));
+        assert_eq!(a.fresh, Some(false));
+        assert!(a.note.contains("not echoed"), "got {}", a.note);
+    }
+
+    #[test]
+    fn runtime_data_that_does_not_hash_to_the_quote_names_nobody() {
+        // A structure swapped for one naming a different signer: it no longer reproduces
+        // report_data, so nothing in it may be believed — including the signer.
+        let (_, rd) = crate::report_data::RuntimeData::new(&SIGNER, b"chal")
+            .unwrap()
+            .seal()
+            .unwrap();
+        let (other, _) = crate::report_data::RuntimeData::new(&[0x22; 20], b"chal")
+            .unwrap()
+            .seal()
+            .unwrap();
+        let ev = serde_json::json!({ crate::report_data::EVIDENCE_FIELD: B64.encode(&other) });
+        let a = read_report_data(&ev, &quote_with(&rd), b"chal");
+        assert!(!a.is(&SIGNER));
+        assert!(!a.is(&[0x22; 20]), "the swapped signer must not be believed either");
+        assert!(a.note.contains("does not hash"), "got {}", a.note);
+    }
 }


### PR DESCRIPTION
Layer 1 of the TLS design in [#88](https://github.com/0gfoundation/0g-tapp/issues/88): an app
gets a TLS certificate whose key is derived inside the CVM, and the quote commits to that
key. A client that hashes the certificate it was handed during a handshake and compares
establishes that it reached a TEE serving this app — **no CA, no KMS and no on-chain
registration required for that check to work.**

Verified end to end on real TDX hardware, from outside the cluster. Closes
[#76](https://github.com/0gfoundation/0g-tapp/issues/76) and
[#90](https://github.com/0gfoundation/0g-tapp/issues/90).

## What a client does now

```bash
PIN=$(curl -s http://34.171.164.181:9090/api/apps/evidence-probe/cert)
curl --pinnedpubkey "$PIN" https://35.253.23.114:8080/
# → evidence-probe over TLS, cert derived inside the CVM
```

One 32-byte value and a standard flag. A wrong pin is refused; no flags at all is refused
(self-signed). `evidence-probe` is left running on test-tapp as a reference deployment — the
intended shape rather than a hand-made test: an init container mounts the tapp Unix socket,
calls `get-app-tls-cert` itself, and nginx serves TLS from the result. `nginx.conf` is a mount
file, so its hash is in the on-chain `volumesHash` — the configuration is attested too.

## `report_data` commits to a structure

Breaking for anything that reads it. It was the 20-byte signer left-aligned in 64 bytes, which
filled the field and left nothing to extend with, and a quote carried no way to distinguish a
fresh one from a replayed blob (#76).

```
report_data = sha512(runtime_data)
runtime_data = {"nonce": "0x…", "signer": "0x…", "tls_public_key": "0x…"}
```

The bytes travel beside the quote in the evidence, base64 under `runtime_data`; empty fields
are omitted. `GetEvidenceRequest` gains an optional challenge which the node echoes — a caller
that sends a random one per request can tell a fresh quote from a cached one, while one that
serves cached results to many readers sends nothing.

Both sides hash **the bytes as transmitted** and never re-serialise, so there is no canonical
form for the two to agree on and drift apart over. Which era applies is decided by whether the
field is present, never guessed from the bytes: with it, recompute and read the fields;
without it, take the leading 20 bytes as before. Sending a challenge to a server that predates
the field reports "freshness unproven" rather than a signer failure — the binding still holds,
the server just cannot answer the question.

**tappscan needed the same branch before nodes could be upgraded**
([0g-tapp-verifier#6](https://github.com/0gfoundation/0g-tapp-verifier/issues/6)); it has
landed, and the deployed instance reads 0.4.0 nodes correctly.

## Where the TLS key comes from is a choice

Not a default with a fallback — the two trade the same thing in opposite directions, and
`server.tls_key_source` / `claim-config --tls-key-source` picks.

| | `local` (default) | `kms` |
|---|---|---|
| Derivation | `sha256("tapp-tls-v1" ‖ signer)` | KMS, per `app_id` |
| Binds to | **this instance** | any node of this app |
| Needs | nothing | app registered on chain, cluster reachable |
| Survives a restart | no | **yes** |
| Can be pinned | no | yes |

Local is the default because it asks nothing of the deployer *and* because it says more: the
key never leaves this CVM, so comparing it against `report_data` yields "you are talking to
*this* TEE". The KMS key is reconstructed at whichever node answers and any registered signer
can obtain it, so the same comparison weakens to "some TEE of this app". What it buys is
stability, which is what pinning, Certificate Transparency monitoring and ordinary renewal all
need. The response reports which one produced the key, because a client deciding whether to
pin has to know if it survives a restart.

The derivation is domain-separated and one-way rather than reusing the signer scalar: the
curves differ, and holding the TLS key must say nothing about the identity that signs chain
transactions and decrypts KMS payloads.

`tls_key_source` is claimed rather than read from `config.toml` for the same reason the owner
is — config.toml lives in the image, so a field there means a separate image and separate
reference values per choice. Claimed, it also lands in the measurement, so a verifier can read
out of the event log whether the attested key survives a restart.

## Key material is served only on the Unix socket

`GetAppSecretKey`, `GetSecretResource` and `GetAppTlsCert` each carried a check that the caller
was "localhost or a same-host Docker container". The code did not do that — it accepted every
RFC1918 address, so on a cloud VM any machine in the same VPC could reach `0.0.0.0:50051` from
a 10.x address and pull any app's private key. The message said one thing and the predicate
another.

The socket is the honest control: `main.rs` already creates it 0600 inside a 0700 directory, so
reaching it means the filesystem handed you a descriptor. tonic records connect-info per
listener and a TCP connection always carries a peer address while a Unix one never does, so the
transport answers the question and nothing is inferred. The decision moved into `AuthLayer` as
`MethodPermission::LocalOnly`, beside every other reachability rule; previously it lived in
three handlers while auth_layer said "Public", so an auditor reading the layer alone would
conclude these were open.

Callers on the socket are unaffected — the KMS cluster already mounts it. **broker and sandbox
use `host.docker.internal:50051` and must mount the socket instead**; their hosts are being
rebuilt.

## A drifted signer now replaces the dead node (#90)

A restart re-derives the signer, so the address on chain belongs to an instance that no longer
exists — the only situation either registration command exists for, and neither handled it.
`update-node-onchain` defaulted *both* old and new signer to the same lookup, so it asked the
chain to replace X with X: a no-op when the chain already held the current signer, and "old
node not found" the moment it did not. `--register-onchain` added a node each time, leaving the
dead address registered, holding stake, and being fetched for evidence it cannot produce —
three had accumulated on the test app before anyone noticed.

That also deadlocked in KMS mode: an app that cannot start without its certificate cannot start
until its signer is on chain, and getting it there wanted a command that needs the app started.
Both now share one rule, which declines to guess — one other node on chain is unambiguously the
predecessor, several are not, so `--old-signer` is requested rather than someone else's stake
being moved.

## Also here

- **`get_secret_resource` is measured.** `get_app_secret_key` always was, but this is the path
  by which a KMS-derived key is obtained and nothing recorded it, so "re-acquiring a key leaves
  a trace" was assumed rather than true.
- **`key_type` stops lying.** The proto advertised `"ethereum", "rsa", "ec"`; only ethereum
  ever existed, and `GetAppKey` accepted the field and discarded it, so `--key-type rsa`
  returned ethereum material while tapp-cli printed "rsa" back from what the client had sent.
  Unknown values are refused; the flag, which never did anything, is gone.
- **A KMS fetch failed when it was an app's first call** — `get_private_key` only reads the
  cache while `get_app_key` is create-if-missing. `GetSecretResource` always had this; asking
  for a certificate as a first action is what exposed it.
- **A test walks the proto** and fails if any RPC reaches the OwnerOnly fallback without being
  classified on purpose. It immediately found two that had been doing so for a long time.

## Found by running it, not by reading it

Worth recording, because none of these were visible from the source:

- the new RPC was unreachable — new methods fall through to OwnerOnly, so an app container got
  "Missing signature" from a rule nobody had chosen
- `material` is hex-decoded by the KMS cluster, so the readable `"tls"` came back as a 500 with
  nothing on this side to suggest why
- the KMS-derived secret **is** a valid P-256 scalar, so refusing rather than reducing an
  out-of-range one stays the right call
- KMS's view of the chain lags a registration by minutes, so a certificate fetch right after
  registering fails and succeeds on retry

## Versions

tapp-server and tapp-cli both 0.4.0 — the gRPC interface changed and `--key-type` is gone from
`get-app-key`. An old CLI passing `"rsa"` starts failing, which is the point: it was failing
silently before.

## Not in this branch

`ratls://` in the client, the KMS-rooted CA, and the browser path (ACME, CAA, CT monitoring)
are later phases in #88. The one gap worth knowing about: fetching the pin from tappscan
currently goes over cleartext HTTP, which makes the pin decorative against an on-path
attacker — HTTPS on tappscan is a precondition for that endpoint meaning anything, tracked in
0g-tapp-verifier#6.
