### PR TITLE
chore(verifier): reference values gcp uki v0.4.0 prod

### DIFF
--- a/verifier/reference-values/gcp/uki/v0.4.0/prod.json
+++ b/verifier/reference-values/gcp/uki/v0.4.0/prod.json
@@ -1,0 +1,5 @@
+{
+  "measurement.uki.SHA-384": [
+    "534cd6fa936b6b6e763da07beccde33c6c0a412529b893ae6590339747c2056c0c00e98299c48d21772d2ef5e6507ece"
+  ]
+}


### PR DESCRIPTION
Auto-generated by build-cvm (canonical mode) for gcp/uki v0.4.0/prod. Registered on AS as policy `0g-tapp-gcp-uki-v0.4.0-prod_cpu`.