### PR TITLE
chore(verifier): reference values gcp uki v0.4.0 dev

### DIFF
--- a/verifier/reference-values/gcp/uki/v0.4.0/dev.json
+++ b/verifier/reference-values/gcp/uki/v0.4.0/dev.json
@@ -1,0 +1,5 @@
+{
+  "measurement.uki.SHA-384": [
+    "e01240c3569cd3f78c9cb452c64cf8050e9f70612074c2f49b4d1fd8d01fef67749dc85cb704142bf9fc96d4c939a894"
+  ]
+}


### PR DESCRIPTION
Auto-generated by build-cvm (canonical mode) for gcp/uki v0.4.0/dev. Registered on AS as policy `0g-tapp-gcp-uki-v0.4.0-dev_cpu`.