### PR TITLE
chore(verifier): reference values gcp uki v0.5.0 dev

### DIFF
--- a/verifier/reference-values/gcp/uki/v0.5.0/dev.json
+++ b/verifier/reference-values/gcp/uki/v0.5.0/dev.json
@@ -1,0 +1,5 @@
+{
+  "measurement.uki.SHA-384": [
+    "55ae2a1c088b2e7218b11aee5946317ab95dbee3452496fc5938ea49178ad5e86250d6825ee9ea887e4973038ef0ff70"
+  ]
+}


### PR DESCRIPTION
Auto-generated by build-cvm (canonical mode) for gcp/uki v0.5.0/dev. Registered on AS as policy `0g-tapp-gcp-uki-v0.5.0-dev_cpu`.