### PR TITLE
chore(verifier): reference values gcp uki v0.6.0 dev

### DIFF
--- a/verifier/reference-values/gcp/uki/v0.6.0/dev.json
+++ b/verifier/reference-values/gcp/uki/v0.6.0/dev.json
@@ -1,0 +1,5 @@
+{
+  "measurement.uki.SHA-384": [
+    "be537925ef0f97a9c14ebc0f972fed18daf0ab4a0ed740c8337a8946a7604c88ca50dd8e9fed655e32a5cea1b80f2f13"
+  ]
+}


### PR DESCRIPTION
Auto-generated by build-cvm (canonical mode) for gcp/uki v0.6.0/dev. Registered on AS as policy `0g-tapp-gcp-uki-v0.6.0-dev_cpu`.