### PR TITLE
chore(verifier): reference values gcp uki v0.7.0 dev

### DIFF
--- a/verifier/reference-values/gcp/uki/v0.7.0/dev.json
+++ b/verifier/reference-values/gcp/uki/v0.7.0/dev.json
@@ -1,0 +1,5 @@
+{
+  "measurement.uki.SHA-384": [
+    "d46fa2f61b17d71f665ae44267b5d5eb5b528fb489ced362e5098dceb9b3aad5febe7dda89953ceae153b352305e66fa"
+  ]
+}


### PR DESCRIPTION
Auto-generated by build-cvm (canonical mode) for gcp/uki v0.7.0/dev. Registered on AS as policy `0g-tapp-gcp-uki-v0.7.0-dev_cpu`.