### PR TITLE
chore(verifier): reference values gcp uki v0.7.0 prod

### DIFF
--- a/verifier/reference-values/gcp/uki/v0.7.0/prod.json
+++ b/verifier/reference-values/gcp/uki/v0.7.0/prod.json
@@ -1,0 +1,5 @@
+{
+  "measurement.uki.SHA-384": [
+    "6235678fbc8daaa2983dce3f7e6797851cd3dba723d859aa86f81b32c8bac180dea9072430542cb0ab681d3cc8ac4f80"
+  ]
+}


### PR DESCRIPTION
Auto-generated by build-cvm (canonical mode) for gcp/uki v0.7.0/prod. Registered on AS as policy `0g-tapp-gcp-uki-v0.7.0-prod_cpu`.