### PR TITLE
chore(verifier): reference values gcp uki v0.7.0-r2 dev

### DIFF
--- a/verifier/reference-values/gcp/uki/v0.7.0-r2/dev.json
+++ b/verifier/reference-values/gcp/uki/v0.7.0-r2/dev.json
@@ -1,0 +1,5 @@
+{
+  "measurement.uki.SHA-384": [
+    "a41d586b5de1ca1d24e389301b6c3440e768dadaf556d8fdd2e57b9e281e91b29ee50832ed1f1c9c4b410da63a918111"
+  ]
+}


### PR DESCRIPTION
Reference values for the `test-encrypted-remote` image built from `feat/encrypted-remote-access` (build-cvm run 34103195361, gcp/uki, v0.7.0-r2 dev variant — first image carrying the baked tapp-front on :50052).

Opened by hand: the workflow's final `gh pr create` step failed with HTTP 401 (RELEASE_PAT expired) after the branch was already pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)