### PR TITLE
chore(verifier): reference values gcp uki v0.8.0 dev

### DIFF
--- a/verifier/reference-values/gcp/uki/v0.8.0/dev.json
+++ b/verifier/reference-values/gcp/uki/v0.8.0/dev.json
@@ -1,0 +1,5 @@
+{
+  "measurement.uki.SHA-384": [
+    "9c8fbc7b77fed0908475c60be5f61bec385728eafa4629415c5591d5216b9be98231da0b0455237eeadebf24d52a9866"
+  ]
+}


### PR DESCRIPTION
Auto-generated by build-cvm (canonical mode) for gcp/uki v0.8.0/dev. Registered on AS as policy `0g-tapp-gcp-uki-v0.8.0-dev_cpu`.